### PR TITLE
Graphql pagination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,33 @@
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
             <version>11.0</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>reactive-streams</artifactId>
+                    <groupId>org.reactivestreams</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>io.reactivex.rxjava2</groupId>
+            <artifactId>rxjava</artifactId>
+            <version>2.2.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.akarnokd</groupId>
+            <artifactId>rxjava2-jdk9-interop</artifactId>
+            <version>0.2.3</version>
+        </dependency>
+
+        <!-- Will work with version 1.0.3. -->
+        <!-- See https://github.com/reactive-streams/reactive-streams-jvm/issues/424 -->
+        <!--<dependency>-->
+            <!--<groupId>org.reactivestreams</groupId>-->
+            <!--<artifactId>reactive-streams-flow-adapters</artifactId>-->
+            <!--<version>1.0.2</version>-->
+        <!--</dependency>-->
 
         <dependency>
             <groupId>no.ssb.lds</groupId>
@@ -93,7 +119,7 @@
         <dependency>
             <groupId>no.ssb.lds</groupId>
             <artifactId>linked-data-store-persistence-provider-memory</artifactId>
-            <version>0.2</version>
+            <version>0.3-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
@@ -154,6 +180,10 @@
             <artifactId>hystrix-core</artifactId>
             <version>1.5.12</version>
             <exclusions>
+                <exclusion>
+                    <artifactId>reactive-streams</artifactId>
+                    <groupId>org.reactivestreams</groupId>
+                </exclusion>
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -18,6 +18,9 @@ module no.ssb.lds.core {
     requires java.xml; // TODO this should be in test-scope only!
 
     requires graphql.java;
+    requires io.reactivex.rxjava2;
+    requires org.reactivestreams;
+    requires com.github.akarnokd.rxjava2jdk9interop;
 
     uses PersistenceInitializer;
 

--- a/src/main/java/no/ssb/lds/graphql/GraphQLContext.java
+++ b/src/main/java/no/ssb/lds/graphql/GraphQLContext.java
@@ -1,0 +1,23 @@
+package no.ssb.lds.graphql;
+
+import io.undertow.server.HttpServerExchange;
+
+import java.time.ZonedDateTime;
+
+/**
+ * The context object passed around in the lds graphql executions.'
+ */
+public interface GraphQLContext {
+
+    // TODO: Find a better name. This clashes with graphql-java objects.
+    
+    /**
+     * Returns the undertow server exchange that triggered the execution.
+     */
+    HttpServerExchange getExchange();
+
+    /**
+     * Returns the snapshot used to retrieve data from persistence
+     */
+    ZonedDateTime getSnapshot();
+}

--- a/src/main/java/no/ssb/lds/graphql/GraphQLUndertowContext.java
+++ b/src/main/java/no/ssb/lds/graphql/GraphQLUndertowContext.java
@@ -12,9 +12,9 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * A context object passed around in the graphql executions.
+ * Implementation of {@link GraphQLContext}
  */
-public class GraphqlContext {
+public class GraphQLUndertowContext implements GraphQLContext {
 
     // Name of the snapshot query variable
     static final String SNAPSHOT_QUERY_NAME = "snapshot";
@@ -29,7 +29,7 @@ public class GraphqlContext {
     private final ZonedDateTime snapshot;
     private final ExecutionInput executionInput;
 
-    GraphqlContext(HttpServerExchange exchange, ExecutionInput executionInput) {
+    GraphQLUndertowContext(HttpServerExchange exchange, ExecutionInput executionInput) {
         this.exchange = Objects.requireNonNull(exchange);
         this.executionInput = executionInput;
         // Init snapshot.
@@ -107,13 +107,12 @@ public class GraphqlContext {
         }
     }
 
-    /**
-     * Returns the undertow server exchange that triggered the execution.
-     */
+    @Override
     public HttpServerExchange getExchange() {
         return this.exchange;
     }
 
+    @Override
     public ZonedDateTime getSnapshot() {
         return this.snapshot;
     }

--- a/src/main/java/no/ssb/lds/graphql/GraphqlHttpHandler.java
+++ b/src/main/java/no/ssb/lds/graphql/GraphqlHttpHandler.java
@@ -150,7 +150,7 @@ public class GraphqlHttpHandler implements HttpHandler {
         }
 
         // Add context.
-        executionInput.context(new GraphqlContext(exchange, executionInput.build()));
+        executionInput.context(new GraphQLUndertowContext(exchange, executionInput.build()));
 
         // Execute
         ExecutionResult result = graphQl.execute(executionInput);

--- a/src/main/java/no/ssb/lds/graphql/fetcher/ConnectionFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/ConnectionFetcher.java
@@ -1,0 +1,72 @@
+package no.ssb.lds.graphql.fetcher;
+
+import graphql.relay.Connection;
+import graphql.relay.DefaultConnectionCursor;
+import graphql.relay.DefaultEdge;
+import graphql.relay.Edge;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import no.ssb.lds.api.persistence.json.JsonDocument;
+import no.ssb.lds.graphql.GraphQLContext;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+public abstract class ConnectionFetcher<T> implements DataFetcher<Connection<T>> {
+
+    private static final String AFTER_ARG_NAME = "after";
+    private static final String BEFORE_ARG_NAME = "before";
+    private static final String FIRST_ARG_NAME = "first";
+    private static final String LAST_ARG_NAME = "last";
+
+    private static String getAfterFrom(DataFetchingEnvironment environment) {
+        return environment.getArgument(AFTER_ARG_NAME);
+    }
+
+    private static String getBeforeFrom(DataFetchingEnvironment environment) {
+        return environment.getArgument(BEFORE_ARG_NAME);
+    }
+
+    private static ZonedDateTime getSnapshotFrom(DataFetchingEnvironment environment) {
+        GraphQLContext context = environment.getContext();
+        return context.getSnapshot();
+    }
+
+    private static Integer getLastFrom(DataFetchingEnvironment environment) {
+        Integer last = environment.getArgument(LAST_ARG_NAME);
+        if (last != null && last < 0) {
+            throw new IllegalArgumentException(format("The page size must not be negative: 'last'=%s", last));
+        }
+        return last;
+    }
+
+    private static Integer getFirstFrom(DataFetchingEnvironment environment) {
+        Integer first = environment.getArgument(FIRST_ARG_NAME);
+        if (first != null && first < 0) {
+            throw new IllegalArgumentException(format("The page size must not be negative: 'first'=%s", first));
+        }
+        return first;
+    }
+
+    protected static Edge<Map<String, Object>> toEdge(JsonDocument document) {
+        return new DefaultEdge<>(
+                document.document().toMap(),
+                new DefaultConnectionCursor(document.key().id())
+        );
+    }
+
+    @Override
+    public Connection<T> get(DataFetchingEnvironment environment) throws Exception {
+        return getConnection(
+                getSnapshotFrom(environment),
+                getAfterFrom(environment),
+                getBeforeFrom(environment),
+                getLastFrom(environment),
+                getFirstFrom(environment)
+        );
+    }
+
+    abstract Connection<T> getConnection(ZonedDateTime snapshot, String after, String before, Integer last, Integer first);
+}

--- a/src/main/java/no/ssb/lds/graphql/fetcher/ConnectionFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/ConnectionFetcher.java
@@ -59,14 +59,46 @@ public abstract class ConnectionFetcher<T> implements DataFetcher<Connection<T>>
 
     @Override
     public Connection<T> get(DataFetchingEnvironment environment) throws Exception {
-        return getConnection(
-                getSnapshotFrom(environment),
-                getAfterFrom(environment),
-                getBeforeFrom(environment),
-                getLastFrom(environment),
-                getFirstFrom(environment)
-        );
+        ConnectionParameters parameters = new ConnectionParameters(getSnapshotFrom(environment), getAfterFrom(environment),
+                getBeforeFrom(environment), getLastFrom(environment), getFirstFrom(environment));
+        return getConnection(environment, parameters);
     }
 
-    abstract Connection<T> getConnection(ZonedDateTime snapshot, String after, String before, Integer last, Integer first);
+    abstract Connection<T> getConnection(DataFetchingEnvironment environment, ConnectionParameters connectionParameters);
+
+    public static class ConnectionParameters {
+        private final ZonedDateTime snapshot;
+        private final String after;
+        private final String before;
+        private final Integer last;
+        private final Integer first;
+
+        private ConnectionParameters(ZonedDateTime snapshot, String after, String before, Integer last, Integer first) {
+            this.snapshot = snapshot;
+            this.after = after;
+            this.before = before;
+            this.last = last;
+            this.first = first;
+        }
+
+        public ZonedDateTime getSnapshot() {
+            return snapshot;
+        }
+
+        public String getAfter() {
+            return after;
+        }
+
+        public String getBefore() {
+            return before;
+        }
+
+        public Integer getLast() {
+            return last;
+        }
+
+        public Integer getFirst() {
+            return first;
+        }
+    }
 }

--- a/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceFetcher.java
@@ -5,7 +5,7 @@ import graphql.schema.DataFetchingEnvironment;
 import no.ssb.lds.api.persistence.Transaction;
 import no.ssb.lds.api.persistence.json.JsonDocument;
 import no.ssb.lds.api.persistence.json.JsonPersistence;
-import no.ssb.lds.graphql.GraphqlContext;
+import no.ssb.lds.graphql.GraphQLContext;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
@@ -37,7 +37,7 @@ public class PersistenceFetcher implements DataFetcher<Map<String, Object>> {
 
     @Override
     public Map<String, Object> get(DataFetchingEnvironment environment) throws Exception {
-        GraphqlContext context = environment.getContext();
+        GraphQLContext context = environment.getContext();
         JsonDocument document = readDocument(environment.getArgument("id"), context.getSnapshot());
         return document != null ? document.document().toMap() : null;
     }

--- a/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceLinkFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceLinkFetcher.java
@@ -5,7 +5,7 @@ import graphql.schema.DataFetchingEnvironment;
 import no.ssb.lds.api.persistence.Transaction;
 import no.ssb.lds.api.persistence.json.JsonDocument;
 import no.ssb.lds.api.persistence.json.JsonPersistence;
-import no.ssb.lds.graphql.GraphqlContext;
+import no.ssb.lds.graphql.GraphQLContext;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
@@ -36,7 +36,7 @@ public class PersistenceLinkFetcher implements DataFetcher<Map<String, Object>> 
         Matcher matcher = pattern.matcher(link);
         if (matcher.matches()) {
             String id = matcher.group("id");
-            GraphqlContext context = environment.getContext();
+            GraphQLContext context = environment.getContext();
             JsonDocument document = readDocument(id, context.getSnapshot());
             return document != null ? document.document().toMap() : null;
         } else {

--- a/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceLinksConnectionFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceLinksConnectionFetcher.java
@@ -1,0 +1,56 @@
+package no.ssb.lds.graphql.fetcher;
+
+import graphql.relay.Connection;
+import graphql.relay.SimpleListConnection;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import no.ssb.lds.api.persistence.json.JsonPersistence;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A wrapper around {@link PersistenceLinksFetcher} that support relay style connections.
+ *
+ *
+ */
+public class PersistenceLinksConnectionFetcher implements DataFetcher<Connection<Map<String, Object>>> {
+
+    private final PersistenceLinksFetcher delegate;
+
+    /**
+     * Create a new instance
+     * <p>
+     * Equivalent to calling
+     * <pre><code>
+     *  new new PersistenceLinksConnectionFetcher(
+     *      new PersistenceLinksFetcher(persistence, namespace, field, target));
+     * </code></pre>
+     */
+    public PersistenceLinksConnectionFetcher(JsonPersistence persistence, String namespace, String field,
+                                             String target) {
+        this(new PersistenceLinksFetcher(persistence, namespace, field, target));
+    }
+
+    /**
+     * Create a new instance wrapping the given persistence links fetcher.
+     */
+    public PersistenceLinksConnectionFetcher(PersistenceLinksFetcher fetcher) {
+        this.delegate = Objects.requireNonNull(fetcher);
+    }
+
+    @Override
+    public Connection<Map<String, Object>> get(DataFetchingEnvironment environment) throws Exception {
+
+        // TODO: Use real streaming.
+        // Not really efficient at all but the persistence API does not provide pagination yet.
+        // We could use the search API to implement this in a later stage if we put the id of
+        // the source in the target of the one to many relations.
+
+        List<Map<String, Object>> list = delegate.get(environment);
+        SimpleListConnection<Map<String, Object>> connection = new SimpleListConnection<>(list);
+
+        return connection.get(environment);
+    }
+}

--- a/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceLinksConnectionFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceLinksConnectionFetcher.java
@@ -12,8 +12,6 @@ import java.util.Objects;
 
 /**
  * A wrapper around {@link PersistenceLinksFetcher} that support relay style connections.
- *
- *
  */
 public class PersistenceLinksConnectionFetcher implements DataFetcher<Connection<Map<String, Object>>> {
 

--- a/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceLinksConnectionFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceLinksConnectionFetcher.java
@@ -1,54 +1,165 @@
 package no.ssb.lds.graphql.fetcher;
 
 import graphql.relay.Connection;
-import graphql.relay.SimpleListConnection;
-import graphql.schema.DataFetcher;
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultPageInfo;
+import graphql.relay.Edge;
+import graphql.relay.PageInfo;
 import graphql.schema.DataFetchingEnvironment;
+import io.reactivex.Flowable;
+import no.ssb.lds.api.persistence.Transaction;
+import no.ssb.lds.api.persistence.json.JsonDocument;
 import no.ssb.lds.api.persistence.json.JsonPersistence;
+import no.ssb.lds.api.persistence.streaming.Fragment;
+import no.ssb.lds.api.persistence.streaming.Persistence;
+import no.ssb.lds.graphql.fetcher.api.SimplePersistence;
+import no.ssb.lds.graphql.fetcher.api.SimplePersistenceImplementation;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static hu.akarnokd.rxjava2.interop.FlowInterop.fromFlowPublisher;
 
 /**
  * A wrapper around {@link PersistenceLinksFetcher} that support relay style connections.
  */
-public class PersistenceLinksConnectionFetcher implements DataFetcher<Connection<Map<String, Object>>> {
+public class PersistenceLinksConnectionFetcher extends ConnectionFetcher<Map<String, Object>> {
 
-    private final PersistenceLinksFetcher delegate;
+    // Field name containing the ids of the target.
+    private final String path;
 
-    /**
-     * Create a new instance
-     * <p>
-     * Equivalent to calling
-     * <pre><code>
-     *  new new PersistenceLinksConnectionFetcher(
-     *      new PersistenceLinksFetcher(persistence, namespace, field, target));
-     * </code></pre>
-     */
-    public PersistenceLinksConnectionFetcher(JsonPersistence persistence, String namespace, String field,
-                                             String target) {
-        this(new PersistenceLinksFetcher(persistence, namespace, field, target));
+    private final String sourceEntityName;
+
+    // Target entity name.
+    private final String targetEntityName;
+
+    // Name space
+    private final String nameSpace;
+
+    private final SimplePersistence persistence;
+    private final Pattern pattern;
+
+    public PersistenceLinksConnectionFetcher(JsonPersistence persistence, String nameSpace, String sourceEntityName, String field, String targetEntityName) {
+        this(persistence.getPersistence(), nameSpace, sourceEntityName, field, targetEntityName);
+    }
+
+    public PersistenceLinksConnectionFetcher(Persistence persistence, String nameSpace, String sourceEntityName, String field, String targetEntityName) {
+        this(new SimplePersistenceImplementation(persistence), nameSpace, sourceEntityName, field, targetEntityName);
+    }
+
+    public PersistenceLinksConnectionFetcher(SimplePersistence persistence, String nameSpace, String sourceEntityName, String field, String targetEntityName) {
+        this.persistence = Objects.requireNonNull(persistence);
+        this.nameSpace = Objects.requireNonNull(nameSpace);
+        this.sourceEntityName = Objects.requireNonNull(sourceEntityName);
+        this.path = "$." + Objects.requireNonNull(field);
+        this.targetEntityName = Objects.requireNonNull(targetEntityName);
+        this.pattern = Pattern.compile("/" + targetEntityName + "/(?<id>.*)");
     }
 
     /**
-     * Create a new instance wrapping the given persistence links fetcher.
+     * Extracts the id from the source object in the environment.
      */
-    public PersistenceLinksConnectionFetcher(PersistenceLinksFetcher fetcher) {
-        this.delegate = Objects.requireNonNull(fetcher);
+    private static String getIdFromSource(DataFetchingEnvironment environment) {
+        Map<String, Object> source = environment.getSource();
+        return (String) source.get("id");
     }
 
     @Override
-    public Connection<Map<String, Object>> get(DataFetchingEnvironment environment) throws Exception {
+    Connection<Map<String, Object>> getConnection(DataFetchingEnvironment environment, ConnectionParameters parameters) {
+        try (Transaction tx = persistence.createTransaction(true)) {
 
-        // TODO: Use real streaming.
-        // Not really efficient at all but the persistence API does not provide pagination yet.
-        // We could use the search API to implement this in a later stage if we put the id of
-        // the source in the target of the one to many relations.
+            String sourceId = getIdFromSource(environment);
 
-        List<Map<String, Object>> list = delegate.get(environment);
-        SimpleListConnection<Map<String, Object>> connection = new SimpleListConnection<>(list);
+            Flow.Publisher<Fragment> fragmentPublisher = persistence.readFragments(tx, parameters.getSnapshot(),
+                    nameSpace, sourceEntityName, sourceId);
 
-        return connection.get(environment);
+            // TODO: Refactor the API so that we can ask for a particular path with id.
+            AtomicReference<String> first = new AtomicReference<>(null);
+            AtomicReference<String> last = new AtomicReference<>(null);
+
+            Flowable<String> idFlowable = fromFlowPublisher(fragmentPublisher)
+                    .filter(fragment -> {
+                        // Keep fragments of relation field.
+                        return fragment.path().startsWith(path);
+                    }).map(fragment -> {
+                        String id = new String(fragment.value());
+                        Matcher matcher = pattern.matcher(id);
+                        if (matcher.matches()) {
+                            return matcher.group("id");
+                        } else {
+                            throw new IllegalStateException("invalid relation value: " + id);
+                        }
+                    }).doOnNext(id -> {
+                        if (!first.compareAndSet(null, id)) {
+                            last.set(id);
+                        }
+                    });
+
+            String after = parameters.getAfter();
+            if (after != null) {
+                idFlowable = idFlowable.filter(id -> {
+                    return id.compareTo(after) > 0;
+                });
+            }
+
+            String before = parameters.getBefore();
+            if (before != null) {
+                idFlowable = idFlowable.takeWhile(id -> {
+                    return id.compareTo(before) < 0;
+                });
+            }
+
+            if (parameters.getFirst() != null) {
+                idFlowable = idFlowable.limit(parameters.getFirst() + 1);
+            }
+            if (parameters.getLast() != null) {
+                idFlowable = idFlowable.takeLast(parameters.getLast());
+            }
+
+            // TODO: Find out why we need to use concatMapEager here to avoid "Previous fragment was not published!"
+            // from PrimaryIterator.
+            Flowable<JsonDocument> documentFlowable = idFlowable.concatMapEager(tardetId -> {
+                return fromFlowPublisher(persistence.readDocument(tx, parameters.getSnapshot(), nameSpace,
+                        targetEntityName, tardetId));
+            });
+
+            List<Edge<Map<String, Object>>> edges = documentFlowable.map(document -> toEdge(document)).toList()
+                    .blockingGet();
+
+            if (edges.isEmpty()) {
+                PageInfo pageInfo = new DefaultPageInfo(null, null, false,
+                        false);
+                return new DefaultConnection<>(Collections.emptyList(), pageInfo);
+            }
+
+            if (parameters.getFirst() != null) {
+                edges = edges.subList(0, parameters.getFirst());
+            }
+
+            Edge<Map<String, Object>> firstEdge = edges.get(0);
+            Edge<Map<String, Object>> lastEdge = edges.get(edges.size() - 1);
+
+            boolean hasPrevious = !firstEdge.getCursor().getValue().equals(first.get());
+            boolean hasNext = !lastEdge.getCursor().getValue().equals(last.get());
+
+            PageInfo pageInfo = new DefaultPageInfo(
+                    firstEdge.getCursor(),
+                    lastEdge.getCursor(),
+                    hasPrevious,
+                    hasNext
+            );
+
+            return new DefaultConnection<>(
+                    edges,
+                    pageInfo
+            );
+
+        }
     }
 }

--- a/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceLinksFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceLinksFetcher.java
@@ -5,7 +5,7 @@ import graphql.schema.DataFetchingEnvironment;
 import no.ssb.lds.api.persistence.Transaction;
 import no.ssb.lds.api.persistence.json.JsonDocument;
 import no.ssb.lds.api.persistence.json.JsonPersistence;
-import no.ssb.lds.graphql.GraphqlContext;
+import no.ssb.lds.graphql.GraphQLContext;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -43,7 +43,7 @@ public class PersistenceLinksFetcher implements DataFetcher<List<Map<String, Obj
             Matcher matcher = pattern.matcher(link);
             if (matcher.matches()) {
                 String id = matcher.group("id");
-                GraphqlContext context = environment.getContext();
+                GraphQLContext context = environment.getContext();
                 JsonDocument document = readDocument(id, context.getSnapshot());
                 results.add(document != null ? document.document().toMap() : null);
             } else {

--- a/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceRootConnectionFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceRootConnectionFetcher.java
@@ -31,7 +31,7 @@ import static java.lang.String.format;
  */
 public class PersistenceRootConnectionFetcher implements DataFetcher<Connection<Map<String, Object>>> {
 
-    public static final String AFTER_ARG_NAME = "after";
+    private static final String AFTER_ARG_NAME = "after";
     private static final String BEFORE_ARG_NAME = "before";
     private static final String FIRST_ARG_NAME = "first";
     private static final String LAST_ARG_NAME = "last";

--- a/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceRootConnectionFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceRootConnectionFetcher.java
@@ -6,7 +6,6 @@ import graphql.relay.DefaultConnectionCursor;
 import graphql.relay.DefaultEdge;
 import graphql.relay.DefaultPageInfo;
 import graphql.relay.Edge;
-import graphql.relay.InvalidPageSizeException;
 import graphql.relay.PageInfo;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -14,17 +13,22 @@ import no.ssb.lds.api.persistence.Transaction;
 import no.ssb.lds.api.persistence.json.JsonDocument;
 import no.ssb.lds.api.persistence.json.JsonPersistence;
 import no.ssb.lds.graphql.GraphQLContext;
+import no.ssb.lds.graphql.fetcher.api.SimplePersistence;
+import no.ssb.lds.graphql.fetcher.api.SimplePersistenceImplementation;
 
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.Flow;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static hu.akarnokd.rxjava2.interop.FlowInterop.fromFlowPublisher;
 import static java.lang.String.format;
+import static no.ssb.lds.graphql.fetcher.api.SimplePersistence.Range;
 
 /**
  * Root fetcher that supports relay style connections.
@@ -36,12 +40,12 @@ public class PersistenceRootConnectionFetcher implements DataFetcher<Connection<
     private static final String FIRST_ARG_NAME = "first";
     private static final String LAST_ARG_NAME = "last";
 
-    private final JsonPersistence persistence;
+    private final SimplePersistence persistence;
     private String nameSpace;
     private String entityName;
 
     public PersistenceRootConnectionFetcher(JsonPersistence persistence, String nameSpace, String entityName) {
-        this.persistence = Objects.requireNonNull(persistence);
+        this.persistence = new SimplePersistenceImplementation(Objects.requireNonNull(persistence.getPersistence()));
         this.nameSpace = Objects.requireNonNull(nameSpace);
         this.entityName = Objects.requireNonNull(entityName);
     }
@@ -81,32 +85,49 @@ public class PersistenceRootConnectionFetcher implements DataFetcher<Connection<
         Integer last = getLastFrom(environment);
 
         try (Transaction tx = persistence.createTransaction(true)) {
-            // TODO: Refactor when persistence supports after and before parameters.
-            Iterable<JsonDocument> completedSlice = persistence.findAll(
-                    tx, snapshot, nameSpace, entityName, null, Integer.MAX_VALUE).join();
 
-            Stream<JsonDocument> stream = StreamSupport.stream(completedSlice.spliterator(), false);
+            Range range = Range.between(
+                    getAfterFrom(environment),
+                    getBeforeFrom(environment)
+            );
 
-            // TODO: Persistence should support this.
-            AtomicReference<JsonDocument> firstSeen = new AtomicReference<>(null);
-            AtomicReference<JsonDocument> lastSeen = new AtomicReference<>(null);
-            stream = stream.peek(document -> {
-                if (!firstSeen.compareAndSet(null, document)) {
-                    lastSeen.set(document);
-                }
-            });
+            Flow.Publisher<JsonDocument> documents = persistence.readDocuments(tx, snapshot, nameSpace, entityName, range);
+            // TODO: Should probably be included in the API.
+            Stream<JsonDocument> stream = StreamSupport.stream(
+                    fromFlowPublisher(documents).blockingIterable().spliterator(),
+                    false
+            );
 
-            String after = getAfterFrom(environment);
-            if (after != null) {
-                stream = stream.dropWhile(jsonDocument -> jsonDocument.key().id().compareTo(after) <= 0);
-            }
-            String before = getBeforeFrom(environment);
-            if (before != null) {
-                stream = stream.takeWhile(jsonDocument -> jsonDocument.key().id().compareTo(before) < 0);
-            }
+            // Reactive stream API
+            //Flowable<JsonDocument> flowable = findAllFlowable(tx, snapshot, nameSpace, entityName, null, Integer.MAX_VALUE);
+            //Stream<JsonDocument> stream = StreamSupport.stream(() -> flowable.blockingIterable().spliterator(), 0, false);
+
+
+            //// TODO: Persistence should support this.
+            //AtomicReference<JsonDocument> firstSeen = new AtomicReference<>(null);
+            //AtomicReference<JsonDocument> lastSeen = new AtomicReference<>(null);
+            //stream = stream.peek(document -> {
+            //    if (!firstSeen.compareAndSet(null, document)) {
+            //        lastSeen.set(document);
+            //    }
+            //});
+
+            //String after = getAfterFrom(environment);
+            //if (after != null) {
+            //    stream = stream.dropWhile(jsonDocument -> jsonDocument.key().id().compareTo(after) <= 0);
+            //}
+            //String before = getBeforeFrom(environment);
+            //if (before != null) {
+            //    stream = stream.takeWhile(jsonDocument -> jsonDocument.key().id().compareTo(before) < 0);
+            //}
 
             List<Edge<Map<String, Object>>> edges = stream.map(document -> toEdge(document))
                     .collect(Collectors.toList());
+
+            if (edges.isEmpty()) {
+                PageInfo pageInfo = new DefaultPageInfo(null, null, false, false);
+                return new DefaultConnection<>(Collections.emptyList(), pageInfo);
+            }
 
             if (first != null) {
                 if (first < 0) {
@@ -127,8 +148,8 @@ public class PersistenceRootConnectionFetcher implements DataFetcher<Connection<
             PageInfo pageInfo = new DefaultPageInfo(
                     firstEdge.getCursor(),
                     lastEdge.getCursor(),
-                    !firstEdge.getCursor().equals(toEdge(firstSeen.get()).getCursor()),
-                    !lastEdge.getCursor().equals(toEdge(lastSeen.get()).getCursor())
+                    true, //!firstEdge.getCursor().equals(toEdge(firstSeen.get()).getCursor()),
+                    true //!lastEdge.getCursor().equals(toEdge(lastSeen.get()).getCursor())
             );
 
             return new DefaultConnection<>(

--- a/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceRootConnectionFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceRootConnectionFetcher.java
@@ -2,18 +2,13 @@ package no.ssb.lds.graphql.fetcher;
 
 import graphql.relay.Connection;
 import graphql.relay.DefaultConnection;
-import graphql.relay.DefaultConnectionCursor;
-import graphql.relay.DefaultEdge;
 import graphql.relay.DefaultPageInfo;
 import graphql.relay.Edge;
 import graphql.relay.PageInfo;
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
 import io.reactivex.Flowable;
 import no.ssb.lds.api.persistence.Transaction;
 import no.ssb.lds.api.persistence.json.JsonDocument;
 import no.ssb.lds.api.persistence.json.JsonPersistence;
-import no.ssb.lds.graphql.GraphQLContext;
 import no.ssb.lds.graphql.fetcher.api.SimplePersistence;
 import no.ssb.lds.graphql.fetcher.api.SimplePersistenceImplementation;
 
@@ -22,24 +17,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.Flow;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static hu.akarnokd.rxjava2.interop.FlowInterop.fromFlowPublisher;
-import static java.lang.String.format;
 import static no.ssb.lds.graphql.fetcher.api.SimplePersistence.Range;
 
 /**
  * Root fetcher that supports relay style connections.
  */
-public class PersistenceRootConnectionFetcher implements DataFetcher<Connection<Map<String, Object>>> {
+public class PersistenceRootConnectionFetcher extends ConnectionFetcher<Map<String, Object>> {
 
-    private static final String AFTER_ARG_NAME = "after";
-    private static final String BEFORE_ARG_NAME = "before";
-    private static final String FIRST_ARG_NAME = "first";
-    private static final String LAST_ARG_NAME = "last";
 
     private final SimplePersistence persistence;
     private String nameSpace;
@@ -51,63 +37,21 @@ public class PersistenceRootConnectionFetcher implements DataFetcher<Connection<
         this.entityName = Objects.requireNonNull(entityName);
     }
 
-    private static Edge<Map<String, Object>> toEdge(JsonDocument document) {
-        return new DefaultEdge<>(
-                document.document().toMap(),
-                new DefaultConnectionCursor(document.key().id())
-        );
-    }
-
-    private static String getAfterFrom(DataFetchingEnvironment environment) {
-        return environment.getArgument(AFTER_ARG_NAME);
-    }
-
-    private static String getBeforeFrom(DataFetchingEnvironment environment) {
-        return environment.getArgument(BEFORE_ARG_NAME);
-    }
-
-    private static ZonedDateTime getSnapshotFrom(DataFetchingEnvironment environment) {
-        GraphQLContext context = environment.getContext();
-        return context.getSnapshot();
-    }
-
-    private static Integer getLastFrom(DataFetchingEnvironment environment) {
-        return environment.getArgument(LAST_ARG_NAME);
-    }
-
-    private static Integer getFirstFrom(DataFetchingEnvironment environment) {
-        return environment.getArgument(FIRST_ARG_NAME);
-    }
-
     @Override
-    public Connection<Map<String, Object>> get(DataFetchingEnvironment environment) throws Exception {
-        ZonedDateTime snapshot = getSnapshotFrom(environment);
-        Integer first = getFirstFrom(environment);
-        Integer last = getLastFrom(environment);
-
+    Connection<Map<String, Object>> getConnection(ZonedDateTime snapshot, String after, String before, Integer last, Integer first) {
         try (Transaction tx = persistence.createTransaction(true)) {
 
-            String after = getAfterFrom(environment);
-            String before = getBeforeFrom(environment);
-            Range range = Range.between(
-                    after,
-                    before
-            );
-
             Flowable<JsonDocument> documentFlowable = fromFlowPublisher(
-                    persistence.readDocuments(tx, snapshot, nameSpace, entityName, range)
+                    persistence.readDocuments(tx, snapshot, nameSpace, entityName, Range.between(
+                            after,
+                            before
+                    ))
             );
 
             if (first != null) {
-                if (first < 0) {
-                    throw new IllegalArgumentException(format("The page size must not be negative: 'first'=%s", first));
-                }
                 documentFlowable = documentFlowable.limit(first);
             }
             if (last != null) {
-                if (last < 0) {
-                    throw new IllegalArgumentException(format("The page size must not be negative: 'last'=%s", last));
-                }
                 documentFlowable = documentFlowable.takeLast(last);
             }
 
@@ -122,10 +66,10 @@ public class PersistenceRootConnectionFetcher implements DataFetcher<Connection<
             Edge<Map<String, Object>> lastEdge = edges.get(edges.size() - 1);
 
             boolean hasPrevious = persistence.hasPrevious(tx, snapshot, nameSpace, entityName,
-                        firstEdge.getCursor().getValue());
+                    firstEdge.getCursor().getValue());
 
             boolean hasNext = persistence.hasNext(tx, snapshot, nameSpace, entityName,
-                        lastEdge.getCursor().getValue());
+                    lastEdge.getCursor().getValue());
 
             PageInfo pageInfo = new DefaultPageInfo(
                     firstEdge.getCursor(),

--- a/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceRootConnectionFetcher.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/PersistenceRootConnectionFetcher.java
@@ -1,0 +1,141 @@
+package no.ssb.lds.graphql.fetcher;
+
+import graphql.relay.Connection;
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultConnectionCursor;
+import graphql.relay.DefaultEdge;
+import graphql.relay.DefaultPageInfo;
+import graphql.relay.Edge;
+import graphql.relay.InvalidPageSizeException;
+import graphql.relay.PageInfo;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import no.ssb.lds.api.persistence.Transaction;
+import no.ssb.lds.api.persistence.json.JsonDocument;
+import no.ssb.lds.api.persistence.json.JsonPersistence;
+import no.ssb.lds.graphql.GraphQLContext;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static java.lang.String.format;
+
+/**
+ * Root fetcher that supports relay style connections.
+ */
+public class PersistenceRootConnectionFetcher implements DataFetcher<Connection<Map<String, Object>>> {
+
+    public static final String AFTER_ARG_NAME = "after";
+    private static final String BEFORE_ARG_NAME = "before";
+    private static final String FIRST_ARG_NAME = "first";
+    private static final String LAST_ARG_NAME = "last";
+
+    private final JsonPersistence persistence;
+    private String nameSpace;
+    private String entityName;
+
+    public PersistenceRootConnectionFetcher(JsonPersistence persistence, String nameSpace, String entityName) {
+        this.persistence = Objects.requireNonNull(persistence);
+        this.nameSpace = Objects.requireNonNull(nameSpace);
+        this.entityName = Objects.requireNonNull(entityName);
+    }
+
+    private static Edge<Map<String, Object>> toEdge(JsonDocument document) {
+        return new DefaultEdge<>(
+                document.document().toMap(),
+                new DefaultConnectionCursor(document.key().id())
+        );
+    }
+
+    private static String getAfterFrom(DataFetchingEnvironment environment) {
+        return environment.getArgument(AFTER_ARG_NAME);
+    }
+
+    private static String getBeforeFrom(DataFetchingEnvironment environment) {
+        return environment.getArgument(BEFORE_ARG_NAME);
+    }
+
+    private static ZonedDateTime getSnapshotFrom(DataFetchingEnvironment environment) {
+        GraphQLContext context = environment.getContext();
+        return context.getSnapshot();
+    }
+
+    private static Integer getLastFrom(DataFetchingEnvironment environment) {
+        return environment.getArgument(LAST_ARG_NAME);
+    }
+
+    private static Integer getFirstFrom(DataFetchingEnvironment environment) {
+        return environment.getArgument(FIRST_ARG_NAME);
+    }
+
+    @Override
+    public Connection<Map<String, Object>> get(DataFetchingEnvironment environment) throws Exception {
+        ZonedDateTime snapshot = getSnapshotFrom(environment);
+        Integer first = getFirstFrom(environment);
+        Integer last = getLastFrom(environment);
+
+        try (Transaction tx = persistence.createTransaction(true)) {
+            // TODO: Refactor when persistence supports after and before parameters.
+            Iterable<JsonDocument> completedSlice = persistence.findAll(
+                    tx, snapshot, nameSpace, entityName, null, Integer.MAX_VALUE).join();
+
+            Stream<JsonDocument> stream = StreamSupport.stream(completedSlice.spliterator(), false);
+
+            // TODO: Persistence should support this.
+            AtomicReference<JsonDocument> firstSeen = new AtomicReference<>(null);
+            AtomicReference<JsonDocument> lastSeen = new AtomicReference<>(null);
+            stream = stream.peek(document -> {
+                if (!firstSeen.compareAndSet(null, document)) {
+                    lastSeen.set(document);
+                }
+            });
+
+            String after = getAfterFrom(environment);
+            if (after != null) {
+                stream = stream.dropWhile(jsonDocument -> jsonDocument.key().id().compareTo(after) <= 0);
+            }
+            String before = getBeforeFrom(environment);
+            if (before != null) {
+                stream = stream.takeWhile(jsonDocument -> jsonDocument.key().id().compareTo(before) < 0);
+            }
+
+            List<Edge<Map<String, Object>>> edges = stream.map(document -> toEdge(document))
+                    .collect(Collectors.toList());
+
+            if (first != null) {
+                if (first < 0) {
+                    throw new IllegalArgumentException(format("The page size must not be negative: 'first'=%s", first));
+                }
+                edges = edges.subList(0, first <= edges.size() ? first : edges.size());
+            }
+            if (last != null) {
+                if (last < 0) {
+                    throw new IllegalArgumentException(format("The page size must not be negative: 'last'=%s", last));
+                }
+                edges = edges.subList(last > edges.size() ? 0 : edges.size() - last, edges.size());
+            }
+
+            Edge<Map<String, Object>> firstEdge = edges.get(0);
+            Edge<Map<String, Object>> lastEdge = edges.get(edges.size() - 1);
+
+            PageInfo pageInfo = new DefaultPageInfo(
+                    firstEdge.getCursor(),
+                    lastEdge.getCursor(),
+                    !firstEdge.getCursor().equals(toEdge(firstSeen.get()).getCursor()),
+                    !lastEdge.getCursor().equals(toEdge(lastSeen.get()).getCursor())
+            );
+
+            return new DefaultConnection<>(
+                    edges,
+                    pageInfo
+            );
+        }
+    }
+
+}

--- a/src/main/java/no/ssb/lds/graphql/fetcher/api/SimplePersistence.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/api/SimplePersistence.java
@@ -1,0 +1,128 @@
+package no.ssb.lds.graphql.fetcher.api;
+
+import no.ssb.lds.api.persistence.PersistenceException;
+import no.ssb.lds.api.persistence.Transaction;
+import no.ssb.lds.api.persistence.json.JsonDocument;
+import no.ssb.lds.api.persistence.streaming.Fragment;
+
+import java.time.ZonedDateTime;
+import java.util.concurrent.Flow;
+import java.util.stream.Stream;
+
+/**
+ * API proposal.
+ */
+public interface SimplePersistence {
+
+    /**
+     * Returns all the {@link Fragment} for a given snapshot, nameSpace, entityName and id.
+     *
+     * @return a {@link Flow.Publisher} of {@link Fragment}
+     * @throws PersistenceException if the persistence failed.
+     */
+    Flow.Publisher<Fragment> readFragments(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName, String id)
+            throws PersistenceException;
+
+    Flow.Publisher<JsonDocument> readDocuments(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName, String id)
+            throws PersistenceException;
+
+    /**
+     * Returns all the {@link Fragment} for a given snapshot, nameSpace and entityName and where the id is after
+     * {@link Range#getAfter()} and before {@link Range#getBefore()}.
+     * <p>
+     * The fragments are published ordered by id last. If {@link Range#getAfter()} or before {@link Range#getBefore()}
+     * return null, the range is unbounded.
+     *
+     * @return a {@link Flow.Publisher} of {@link Fragment}
+     * @throws PersistenceException if the persistence failed.
+     */
+    Flow.Publisher<Fragment> readFragments(Transaction tx, ZonedDateTime snapshot, String nameSpace,
+                                           String entityName, Range range) throws PersistenceException;
+
+    Flow.Publisher<JsonDocument> readDocuments(Transaction tx, ZonedDateTime snapshot, String nameSpace,
+                                               String entityName, Range range) throws PersistenceException;
+
+    Flow.Publisher<Fragment> findFragments(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName,
+                                           Filter filter) throws PersistenceException;
+
+    Flow.Publisher<Fragment> findFragments(Transaction tx, ZonedDateTime snapshot, String nameSpace,
+                                           String entityName, Filter filter, Range range)
+            throws PersistenceException;
+
+    boolean hasPrevious(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName, String id);
+
+    boolean hasNext(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName, String id);
+
+    /**
+     * Uses the transaction-factory to create a new transaction. This method is equivalent
+     * to calling <code>transactionFactory.createTransaction()</code>.
+     *
+     * @param readOnly true if the transaction will only perform read operations, false if at least one write operation
+     *                 will be performed, and false if the caller is unsure. Note that the underlying persistence
+     *                 provider may be able to optimize performance and contention related issues when read-only
+     *                 transactions are involved.
+     * @return the newly created transaction
+     * @throws PersistenceException
+     */
+    Transaction createTransaction(boolean readOnly) throws PersistenceException;
+
+    class Range {
+
+        private final String before;
+        private final String after;
+
+        private Range(String after, String before) {
+            this.before = before;
+            this.after = after;
+        }
+
+        public static Range after(String value) {
+            return between(value, null);
+        }
+
+        public static Range before(String value) {
+            return between(null, value);
+        }
+
+        public static Range between(String first, String last) {
+            return new Range(first, last);
+        }
+
+        static Range unbounded() {
+            return between(null, null);
+        }
+
+        public String getBefore() {
+            return before;
+        }
+
+        public String getAfter() {
+            return after;
+        }
+    }
+
+    class Filter {
+
+        private final String path;
+        private final byte[] pathValue;
+        private final String id;
+
+        public Filter(String path, byte[] pathValue, String id) {
+            this.path = path;
+            this.pathValue = pathValue;
+            this.id = id;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public byte[] getPathValue() {
+            return pathValue;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+}

--- a/src/main/java/no/ssb/lds/graphql/fetcher/api/SimplePersistence.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/api/SimplePersistence.java
@@ -7,7 +7,6 @@ import no.ssb.lds.api.persistence.streaming.Fragment;
 
 import java.time.ZonedDateTime;
 import java.util.concurrent.Flow;
-import java.util.stream.Stream;
 
 /**
  * API proposal.
@@ -23,7 +22,7 @@ public interface SimplePersistence {
     Flow.Publisher<Fragment> readFragments(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName, String id)
             throws PersistenceException;
 
-    Flow.Publisher<JsonDocument> readDocuments(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName, String id)
+    Flow.Publisher<JsonDocument> readDocument(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName, String id)
             throws PersistenceException;
 
     /**

--- a/src/main/java/no/ssb/lds/graphql/fetcher/api/SimplePersistence.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/api/SimplePersistence.java
@@ -10,6 +10,9 @@ import java.util.concurrent.Flow;
 
 /**
  * API proposal.
+ *
+ * TODO: Add reverse order in API.
+ * TODO: Maybe support several ranges.
  */
 public interface SimplePersistence {
 

--- a/src/main/java/no/ssb/lds/graphql/fetcher/api/SimplePersistenceImplementation.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/api/SimplePersistenceImplementation.java
@@ -139,14 +139,16 @@ public class SimplePersistenceImplementation implements SimplePersistence {
 
     @Override
     public boolean hasPrevious(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName, String id) {
-        // TODO.
-        return false;
+        Flow.Publisher<Fragment> fragmentPublisher = readFragments(tx, snapshot, nameSpace, entityName, Range.before(id));
+        Flowable<Fragment> fragmentFlowable = fromFlowPublisher(fragmentPublisher);
+        return !fragmentFlowable.isEmpty().blockingGet();
     }
 
     @Override
     public boolean hasNext(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName, String id) {
-        // TODO.
-        return false;
+        Flow.Publisher<Fragment> fragmentPublisher = readFragments(tx, snapshot, nameSpace, entityName, Range.after(id));
+        Flowable<Fragment> fragmentFlowable = fromFlowPublisher(fragmentPublisher);
+        return !fragmentFlowable.isEmpty().blockingGet();
     }
 
     @Override

--- a/src/main/java/no/ssb/lds/graphql/fetcher/api/SimplePersistenceImplementation.java
+++ b/src/main/java/no/ssb/lds/graphql/fetcher/api/SimplePersistenceImplementation.java
@@ -1,0 +1,156 @@
+package no.ssb.lds.graphql.fetcher.api;
+
+import io.reactivex.Flowable;
+import no.ssb.lds.api.persistence.DocumentKey;
+import no.ssb.lds.api.persistence.PersistenceException;
+import no.ssb.lds.api.persistence.Transaction;
+import no.ssb.lds.api.persistence.flattened.FlattenedDocument;
+import no.ssb.lds.api.persistence.json.FlattenedDocumentToJson;
+import no.ssb.lds.api.persistence.json.JsonDocument;
+import no.ssb.lds.api.persistence.streaming.Fragment;
+import no.ssb.lds.api.persistence.streaming.Persistence;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Flow;
+
+import static hu.akarnokd.rxjava2.interop.FlowInterop.fromFlowPublisher;
+import static hu.akarnokd.rxjava2.interop.FlowInterop.toFlowPublisher;
+
+/**
+ * Wraps the persistence.
+ */
+public class SimplePersistenceImplementation implements SimplePersistence {
+
+    private final Persistence persistence;
+    private int capacityBytes;
+
+    public SimplePersistenceImplementation(Persistence persistence) {
+        this(persistence, null);
+    }
+
+    public SimplePersistenceImplementation(Persistence persistence, Integer capacityBytes) {
+        this.persistence = Objects.requireNonNull(persistence);
+        this.capacityBytes = Optional.ofNullable(capacityBytes).orElse(8192);
+    }
+
+
+    @Override
+    public Flow.Publisher<Fragment> readFragments(Transaction tx, ZonedDateTime snapshot, String nameSpace,
+                                                  String entityName, String id) throws PersistenceException {
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(entityName);
+        Objects.requireNonNull(nameSpace);
+        Objects.requireNonNull(snapshot);
+        Objects.requireNonNull(tx);
+
+        return persistence.read(tx, snapshot, nameSpace, entityName, id);
+    }
+
+    @Override
+    public Flow.Publisher<JsonDocument> readDocuments(Transaction tx, ZonedDateTime snapshot, String nameSpace,
+                                                      String entityName, String id) throws PersistenceException {
+        Flow.Publisher<Fragment> fragmentPublisher = readFragments(tx, snapshot, nameSpace, entityName, id);
+        Flowable<Fragment> fragmentFlowable = fromFlowPublisher(fragmentPublisher);
+        Flowable<JsonDocument> documentFlowable = toDocuments(fragmentFlowable);
+        return toFlowPublisher(documentFlowable);
+    }
+
+    private Flowable<JsonDocument> toDocuments(Flowable<Fragment> fragmentFlowable) {
+        return fragmentFlowable.groupBy(fragment -> {
+            // Fragments by id.
+            return DocumentKey.from(fragment);
+        }).concatMapSingle(fragments -> {
+            // For each group, create a FlattenedDocument.
+            DocumentKey key = fragments.getKey();
+            // Note that we return a Single<FlattenedDocument>. We use concat to "unwrap" them.
+            return fragments.toMultimap(Fragment::path).map(map -> {
+                return FlattenedDocument.decodeDocument(key, map, capacityBytes);
+            });
+        }).filter(flattenedDocument -> {
+            // Filter out the deleted documents.
+            return !flattenedDocument.deleted();
+        }).map(flattenedDocument -> {
+            // Convert to JsonDocument.
+            return new JsonDocument(
+                    flattenedDocument.key(),
+                    new FlattenedDocumentToJson(flattenedDocument).toJSONObject()
+            );
+        });
+    }
+
+    @Override
+    public Flow.Publisher<Fragment> readFragments(Transaction tx, ZonedDateTime snapshot, String nameSpace,
+                                                  String entityName, Range range) throws PersistenceException {
+        Objects.requireNonNull(tx);
+        Objects.requireNonNull(snapshot);
+        Objects.requireNonNull(nameSpace);
+        Objects.requireNonNull(entityName);
+        Objects.requireNonNull(range);
+
+        Flow.Publisher<Fragment> fragmentPublisher = persistence.findAll(tx, snapshot, nameSpace, entityName,
+                range.getAfter(), Integer.MAX_VALUE);
+        Flowable<Fragment> fragmentFlowable = fromFlowPublisher(fragmentPublisher);
+        fragmentFlowable = limitFragments(fragmentFlowable, range);
+        return toFlowPublisher(fragmentFlowable);
+    }
+
+    private Flowable<Fragment> limitFragments(Flowable<Fragment> fragmentFlowable, Range range) {
+        if (range.getAfter() != null) {
+            fragmentFlowable = fragmentFlowable.filter(fragment -> fragment.id().compareTo(range.getAfter()) > 0);
+        }
+        if (range.getBefore() != null) {
+            fragmentFlowable = fragmentFlowable.takeWhile(fragment -> fragment.id().compareTo(range.getBefore()) < 0);
+        }
+        return fragmentFlowable;
+    }
+
+    @Override
+    public Flow.Publisher<JsonDocument> readDocuments(Transaction tx, ZonedDateTime snapshot, String nameSpace,
+                                                      String entityName, Range range) throws PersistenceException {
+        Flow.Publisher<Fragment> fragmentPublisher = readFragments(tx, snapshot, nameSpace, entityName, range);
+        Flowable<Fragment> fragmentFlowable = fromFlowPublisher(fragmentPublisher);
+        Flowable<JsonDocument> documentFlowable = toDocuments(fragmentFlowable);
+        return toFlowPublisher(documentFlowable);
+    }
+
+    @Override
+    public Flow.Publisher<Fragment> findFragments(Transaction tx, ZonedDateTime snapshot, String nameSpace,
+                                                  String entityName, Filter filter) throws PersistenceException {
+        return findFragments(tx, snapshot, nameSpace, entityName, filter, Range.unbounded());
+    }
+
+    @Override
+    public Flow.Publisher<Fragment> findFragments(Transaction tx, ZonedDateTime snapshot, String nameSpace,
+                                                  String entityName, Filter filter, Range range) throws PersistenceException {
+        Objects.requireNonNull(tx);
+        Objects.requireNonNull(snapshot);
+        Objects.requireNonNull(nameSpace);
+        Objects.requireNonNull(entityName);
+        Objects.requireNonNull(filter);
+
+        Flow.Publisher<Fragment> fragmentPublisher = persistence.find(tx, snapshot, nameSpace, entityName,
+                filter.getPath(), filter.getPathValue(), filter.getId(), Integer.MAX_VALUE);
+        Flowable<Fragment> fragmentFlowable = fromFlowPublisher(fragmentPublisher);
+        fragmentFlowable = limitFragments(fragmentFlowable, range);
+        return toFlowPublisher(fragmentFlowable);
+    }
+
+    @Override
+    public boolean hasPrevious(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName, String id) {
+        // TODO.
+        return false;
+    }
+
+    @Override
+    public boolean hasNext(Transaction tx, ZonedDateTime snapshot, String nameSpace, String entityName, String id) {
+        // TODO.
+        return false;
+    }
+
+    @Override
+    public Transaction createTransaction(boolean readOnly) throws PersistenceException {
+        return persistence.createTransaction(readOnly);
+    }
+}

--- a/src/test/java/no/ssb/lds/graphql/GraphQLUndettowContextTest.java
+++ b/src/test/java/no/ssb/lds/graphql/GraphQLUndettowContextTest.java
@@ -11,26 +11,26 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 
-import static no.ssb.lds.graphql.GraphqlContext.SNAPSHOT_QUERY_NAME;
-import static no.ssb.lds.graphql.GraphqlContext.SNAPSHOT_VARIABLE_NAME;
+import static no.ssb.lds.graphql.GraphQLUndertowContext.SNAPSHOT_QUERY_NAME;
+import static no.ssb.lds.graphql.GraphQLUndertowContext.SNAPSHOT_VARIABLE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class GraphqlContextTest {
+public class GraphQLUndettowContextTest {
 
     private ZonedDateTime defaultSnapshot;
 
     @BeforeMethod
     public void setUp() {
         defaultSnapshot = ZonedDateTime.parse("2000-01-01T00:00:00Z");
-        GraphqlContext.CLOCK = Clock.fixed(defaultSnapshot.toInstant(), defaultSnapshot.getZone());
+        GraphQLUndertowContext.CLOCK = Clock.fixed(defaultSnapshot.toInstant(), defaultSnapshot.getZone());
     }
 
     @Test
     public void testVariable() {
         ZonedDateTime givenSnapshot = ZonedDateTime.parse("1999-01-01T00:00:00Z");
         Map<String, Object> variables = Map.of(SNAPSHOT_VARIABLE_NAME, givenSnapshot.toString());
-        ZonedDateTime snapshot = GraphqlContext.getSnapshot(Collections.emptyMap(), variables);
+        ZonedDateTime snapshot = GraphQLUndertowContext.getSnapshot(Collections.emptyMap(), variables);
 
         assertThat(snapshot).isEqualTo(givenSnapshot);
     }
@@ -39,7 +39,7 @@ public class GraphqlContextTest {
     public void testNullVariable() {
         LinkedHashMap<String, Object> variables = new LinkedHashMap<>();
         variables.put(SNAPSHOT_VARIABLE_NAME, null);
-        ZonedDateTime snapshot = GraphqlContext.getSnapshot(Collections.emptyMap(), variables);
+        ZonedDateTime snapshot = GraphQLUndertowContext.getSnapshot(Collections.emptyMap(), variables);
 
         assertThat(snapshot).isEqualTo(defaultSnapshot);
     }
@@ -48,7 +48,7 @@ public class GraphqlContextTest {
     public void testInvalidFormatVariable() {
         Map<String, Object> variables = Map.of(SNAPSHOT_VARIABLE_NAME, "not-a-date-time");
 
-        ZonedDateTime snapshot = GraphqlContext.getSnapshot(Collections.emptyMap(), variables);
+        ZonedDateTime snapshot = GraphQLUndertowContext.getSnapshot(Collections.emptyMap(), variables);
         assertThat(snapshot).isEqualTo(defaultSnapshot);
     }
 
@@ -57,7 +57,7 @@ public class GraphqlContextTest {
         Map<String, Object> variables = Map.of(SNAPSHOT_VARIABLE_NAME, false);
 
         assertThatThrownBy(() -> {
-            GraphqlContext.getSnapshot(Collections.emptyMap(), variables);
+            GraphQLUndertowContext.getSnapshot(Collections.emptyMap(), variables);
         }).isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -67,7 +67,7 @@ public class GraphqlContextTest {
         LinkedList<String> parameters = new LinkedList<>();
         parameters.add(givenSnapshot.toString());
         Map<String, Deque<String>> queryParameters = Map.of(SNAPSHOT_QUERY_NAME, parameters);
-        ZonedDateTime snapshot = GraphqlContext.getSnapshot(queryParameters, Collections.emptyMap());
+        ZonedDateTime snapshot = GraphQLUndertowContext.getSnapshot(queryParameters, Collections.emptyMap());
 
         assertThat(snapshot).isEqualTo(givenSnapshot);
     }
@@ -80,7 +80,7 @@ public class GraphqlContextTest {
         Map<String, Deque<String>> queryParameters = Map.of(SNAPSHOT_QUERY_NAME, parameters);
 
         assertThatThrownBy(() -> {
-            GraphqlContext.getSnapshot(queryParameters, Collections.emptyMap());
+            GraphQLUndertowContext.getSnapshot(queryParameters, Collections.emptyMap());
         }).isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -89,7 +89,7 @@ public class GraphqlContextTest {
         LinkedList<String> parameters = new LinkedList<>();
         parameters.add(null);
         Map<String, Deque<String>> queryParameters = Map.of(SNAPSHOT_QUERY_NAME, parameters);
-        ZonedDateTime snapshot = GraphqlContext.getSnapshot(queryParameters, Collections.emptyMap());
+        ZonedDateTime snapshot = GraphQLUndertowContext.getSnapshot(queryParameters, Collections.emptyMap());
 
         assertThat(snapshot).isEqualTo(defaultSnapshot);
     }
@@ -99,7 +99,7 @@ public class GraphqlContextTest {
         LinkedList<String> parameters = new LinkedList<>();
         parameters.add("not-a-variable");
         Map<String, Deque<String>> queryParameters = Map.of(SNAPSHOT_QUERY_NAME, parameters);
-        ZonedDateTime snapshot = GraphqlContext.getSnapshot(queryParameters, Collections.emptyMap());
+        ZonedDateTime snapshot = GraphQLUndertowContext.getSnapshot(queryParameters, Collections.emptyMap());
 
         assertThat(snapshot).isEqualTo(defaultSnapshot);
     }
@@ -107,7 +107,7 @@ public class GraphqlContextTest {
     @Test
     public void testNoQueryParameterNoVariable() {
         ZonedDateTime snapshot =
-                GraphqlContext.getSnapshot(Collections.emptyMap(), Collections.emptyMap());
+                GraphQLUndertowContext.getSnapshot(Collections.emptyMap(), Collections.emptyMap());
 
         assertThat(snapshot).isEqualTo(defaultSnapshot);
     }
@@ -122,7 +122,7 @@ public class GraphqlContextTest {
         Map<String, Object> variables = Map.of(SNAPSHOT_VARIABLE_NAME, variable.toString());
 
         ZonedDateTime snapshot =
-                GraphqlContext.getSnapshot(queryParameters, variables);
+                GraphQLUndertowContext.getSnapshot(queryParameters, variables);
 
         assertThat(snapshot).isEqualTo(parameter);
     }

--- a/src/test/java/no/ssb/lds/graphql/fetcher/PersistenceLinksConnectionFetcherTest.java
+++ b/src/test/java/no/ssb/lds/graphql/fetcher/PersistenceLinksConnectionFetcherTest.java
@@ -1,0 +1,251 @@
+package no.ssb.lds.graphql.fetcher;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.ExecutionStepInfo;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.relay.Connection;
+import graphql.relay.Edge;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import io.undertow.server.HttpServerExchange;
+import no.ssb.lds.api.persistence.DocumentKey;
+import no.ssb.lds.api.persistence.Transaction;
+import no.ssb.lds.api.persistence.json.JsonDocument;
+import no.ssb.lds.api.persistence.json.JsonPersistence;
+import no.ssb.lds.core.persistence.memory.MemoryInitializer;
+import no.ssb.lds.graphql.GraphQLContext;
+import org.dataloader.DataLoader;
+import org.json.JSONObject;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.time.ZonedDateTime;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PersistenceLinksConnectionFetcherTest {
+    private PersistenceLinksConnectionFetcher connectionFetcher;
+    private ZonedDateTime snapshot;
+    private LinkedHashMap<String, Object> source = new LinkedHashMap<>();
+    private Map<String, JSONObject> data = new LinkedHashMap<>();
+
+    /*
+     * Pagination in GraphQL ar handled using So called Relay Connections.
+     * graphql java comes with a simple implementation
+     *
+     * For each one to many relationship we need:
+     * [FromObject][ToObject]Connection backed by graphql.relay.Connection
+     * [FromObject][ToObject]Egde backed by graphql.relay.Edge.
+     *
+     * Connections also contain graphql.relay.PageInfo
+     */
+
+    @BeforeMethod
+    public void setUp() {
+        JsonPersistence persistence = new MemoryInitializer().initialize("ns",
+                Map.of("persistence.mem.wait.min", "0",
+                        "persistence.mem.wait.max", "0"),
+                Set.of("Source", "Target"));
+        PersistenceLinksFetcher linksFetcher = new PersistenceLinksFetcher(persistence, "ns", "targetIds", "Target");
+        connectionFetcher = new PersistenceLinksConnectionFetcher(linksFetcher);
+        snapshot = ZonedDateTime.now();
+
+        // Populate persistence with fake data.
+        try (Transaction tx = persistence.createTransaction(false)) {
+            for (int i = 0; i < 10; i++) {
+
+                // Save reference for assertions.
+                String entityId = String.format("target-%s", i);
+                JSONObject jsonObject = new JSONObject();
+                jsonObject.put("id", entityId);
+                data.put(String.format("/Target/%s", entityId), jsonObject);
+
+                // Put the document into persistence.
+                DocumentKey key = new DocumentKey("ns", "Target", entityId, snapshot);
+                persistence.createOrOverwrite(
+                        tx,
+                        new JsonDocument(key, jsonObject),
+                        null // not required by memory store?
+                );
+            }
+            source.put("targetIds", new LinkedList<>(data.keySet()));
+        }
+
+
+    }
+
+    @Test
+    public void testForwardPagination() throws Exception {
+        Connection<Map<String, Object>> firstFive = connectionFetcher.get(withArguments(Map.of("first", 5)));
+
+        assertThat(firstFive.getPageInfo().isHasPreviousPage()).isFalse();
+        assertThat(firstFive.getPageInfo().isHasNextPage()).isTrue();
+        assertThat(firstFive.getEdges()).extracting(Edge::getNode).containsExactlyElementsOf(
+                () -> data.values().stream().map(JSONObject::toMap).limit(5).iterator()
+        );
+
+        Connection<Map<String, Object>> lastFive = connectionFetcher.get(withArguments(Map.of("first", 5, "after", firstFive.getPageInfo().getEndCursor().getValue())));
+
+        assertThat(lastFive.getPageInfo().isHasPreviousPage()).isTrue();
+        assertThat(lastFive.getPageInfo().isHasNextPage()).isFalse();
+        assertThat(lastFive.getEdges()).extracting(Edge::getNode).containsExactlyElementsOf(
+                () -> data.values().stream().map(JSONObject::toMap).skip(5).iterator()
+        );
+    }
+
+    @Test
+    public void testBackwardPagination() throws Exception {
+        Connection<Map<String, Object>> lastFive = connectionFetcher.get(withArguments(Map.of("last", 5)));
+
+        assertThat(lastFive.getPageInfo().isHasPreviousPage()).isTrue();
+        assertThat(lastFive.getPageInfo().isHasNextPage()).isFalse();
+        assertThat(lastFive.getEdges()).extracting(Edge::getNode).containsExactlyElementsOf(
+                () -> data.values().stream().map(JSONObject::toMap).skip(5).iterator()
+        );
+
+        Connection<Map<String, Object>> firstFive = connectionFetcher.get(withArguments(Map.of("last", 5, "before", lastFive.getPageInfo().getStartCursor().getValue())));
+
+        assertThat(firstFive.getPageInfo().isHasPreviousPage()).isFalse();
+        assertThat(firstFive.getPageInfo().isHasNextPage()).isTrue();
+        assertThat(firstFive.getEdges()).extracting(Edge::getNode).containsExactlyElementsOf(
+                () -> data.values().stream().map(JSONObject::toMap).limit(5).iterator()
+        );
+    }
+
+    private TestEnvironment withArguments(Map<String, Object> arguments) {
+        return new TestEnvironment(arguments, source, snapshot);
+    }
+
+    /**
+     * For test. Only the interface is marked public.
+     */
+    private static final class TestEnvironment implements DataFetchingEnvironment {
+
+        private final Map<String, Object> arguments;
+        private final Object source;
+        private final ZonedDateTime snapshot;
+
+        private TestEnvironment(
+                Map<String, Object> arguments,
+                Map<String, Object> source,
+                ZonedDateTime snapshot
+        ) {
+            this.arguments = Objects.requireNonNull(arguments);
+            this.source = Objects.requireNonNull(source);
+            this.snapshot = Objects.requireNonNull(snapshot);
+        }
+
+        @Override
+        public <T> T getSource() {
+            return (T) source;
+        }
+
+        @Override
+        public Map<String, Object> getArguments() {
+            return arguments;
+        }
+
+        @Override
+        public boolean containsArgument(String name) {
+            return arguments.containsKey(name);
+        }
+
+        @Override
+        public <T> T getArgument(String name) {
+            return (T) arguments.get(name);
+        }
+
+        @Override
+        public <T> T getContext() {
+            return (T) new GraphQLContext() {
+
+                @Override
+                public HttpServerExchange getExchange() {
+                    return null;
+                }
+
+                @Override
+                public ZonedDateTime getSnapshot() {
+                    return snapshot;
+                }
+            };
+        }
+
+        @Override
+        public <T> T getRoot() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public GraphQLFieldDefinition getFieldDefinition() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Field> getFields() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Field getField() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public GraphQLOutputType getFieldType() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ExecutionStepInfo getExecutionStepInfo() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public GraphQLType getParentType() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public GraphQLSchema getGraphQLSchema() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, FragmentDefinition> getFragmentsByName() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ExecutionId getExecutionId() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DataFetchingFieldSelectionSet getSelectionSet() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ExecutionContext getExecutionContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <K, V> DataLoader<K, V> getDataLoader(String dataLoaderName) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/test/java/no/ssb/lds/graphql/fetcher/PersistenceLinksConnectionFetcherTest.java
+++ b/src/test/java/no/ssb/lds/graphql/fetcher/PersistenceLinksConnectionFetcherTest.java
@@ -20,6 +20,8 @@ import no.ssb.lds.api.persistence.json.JsonDocument;
 import no.ssb.lds.api.persistence.json.JsonPersistence;
 import no.ssb.lds.core.persistence.memory.MemoryInitializer;
 import no.ssb.lds.graphql.GraphQLContext;
+import no.ssb.lds.graphql.fetcher.api.SimplePersistence;
+import no.ssb.lds.graphql.fetcher.api.SimplePersistenceImplementation;
 import org.dataloader.DataLoader;
 import org.json.JSONObject;
 import org.testng.annotations.BeforeMethod;
@@ -58,8 +60,8 @@ public class PersistenceLinksConnectionFetcherTest {
                 Map.of("persistence.mem.wait.min", "0",
                         "persistence.mem.wait.max", "0"),
                 Set.of("Source", "Target"));
-        PersistenceLinksFetcher linksFetcher = new PersistenceLinksFetcher(persistence, "ns", "targetIds", "Target");
-        connectionFetcher = new PersistenceLinksConnectionFetcher(linksFetcher);
+        SimplePersistence simplePersistence = new SimplePersistenceImplementation(persistence.getPersistence());
+        connectionFetcher = new PersistenceLinksConnectionFetcher(simplePersistence, "ns", "Source", "targetIds", "Target");
         snapshot = ZonedDateTime.now();
 
         // Populate persistence with fake data.
@@ -77,10 +79,16 @@ public class PersistenceLinksConnectionFetcherTest {
                 persistence.createOrOverwrite(
                         tx,
                         new JsonDocument(key, jsonObject),
-                        null // not required by memory store?
+                        null // not required by memory store.
                 );
             }
+            source.put("id", "sourceId");
             source.put("targetIds", new LinkedList<>(data.keySet()));
+            DocumentKey key = new DocumentKey("ns", "Source", "sourceId", snapshot);
+            persistence.createOrOverwrite(
+                    tx, new JsonDocument(key, new JSONObject(source)),
+                    null // not required by memory store.
+            );
         }
 
 

--- a/src/test/java/no/ssb/lds/graphql/schemas/GraphqlSchemaBuilderTest.java
+++ b/src/test/java/no/ssb/lds/graphql/schemas/GraphqlSchemaBuilderTest.java
@@ -8,6 +8,7 @@ import no.ssb.lds.api.persistence.Transaction;
 import no.ssb.lds.api.persistence.TransactionFactory;
 import no.ssb.lds.api.persistence.json.JsonDocument;
 import no.ssb.lds.api.persistence.json.JsonPersistence;
+import no.ssb.lds.api.persistence.streaming.Persistence;
 import no.ssb.lds.api.specification.Specification;
 import no.ssb.lds.core.specification.JsonSchemaBasedSpecification;
 import no.ssb.lds.graphql.schemas.GraphqlSchemaBuilder;
@@ -65,6 +66,11 @@ public class GraphqlSchemaBuilderTest {
     }
 
     private class MockPersistence implements JsonPersistence {
+        @Override
+        public Persistence getPersistence() {
+            return null;
+        }
+
         @Override
         public TransactionFactory transactionFactory() throws PersistenceException {
             return null;

--- a/src/test/java/no/ssb/lds/graphql/schemas/GraphqlSchemaBuilderTest.java
+++ b/src/test/java/no/ssb/lds/graphql/schemas/GraphqlSchemaBuilderTest.java
@@ -8,6 +8,7 @@ import no.ssb.lds.api.persistence.Transaction;
 import no.ssb.lds.api.persistence.TransactionFactory;
 import no.ssb.lds.api.persistence.json.JsonDocument;
 import no.ssb.lds.api.persistence.json.JsonPersistence;
+import no.ssb.lds.api.persistence.streaming.Fragment;
 import no.ssb.lds.api.persistence.streaming.Persistence;
 import no.ssb.lds.api.specification.Specification;
 import no.ssb.lds.core.specification.JsonSchemaBasedSpecification;
@@ -16,6 +17,7 @@ import org.testng.annotations.Test;
 
 import java.time.ZonedDateTime;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
 
 public class GraphqlSchemaBuilderTest {
 
@@ -68,7 +70,67 @@ public class GraphqlSchemaBuilderTest {
     private class MockPersistence implements JsonPersistence {
         @Override
         public Persistence getPersistence() {
-            return null;
+            return new Persistence() {
+                @Override
+                public TransactionFactory transactionFactory() throws PersistenceException {
+                    return null;
+                }
+
+                @Override
+                public Transaction createTransaction(boolean readOnly) throws PersistenceException {
+                    return null;
+                }
+
+                @Override
+                public CompletableFuture<Void> createOrOverwrite(Transaction transaction, Flow.Publisher<Fragment> publisher) throws PersistenceException {
+                    return null;
+                }
+
+                @Override
+                public Flow.Publisher<Fragment> read(Transaction transaction, ZonedDateTime snapshot, String namespace, String entity, String id) throws PersistenceException {
+                    return null;
+                }
+
+                @Override
+                public Flow.Publisher<Fragment> readVersions(Transaction transaction, ZonedDateTime snapshotFrom, ZonedDateTime snapshotTo, String namespace, String entity, String id, ZonedDateTime firstVersion, int limit) throws PersistenceException {
+                    return null;
+                }
+
+                @Override
+                public Flow.Publisher<Fragment> readAllVersions(Transaction transaction, String namespace, String entity, String id, ZonedDateTime firstVersion, int limit) throws PersistenceException {
+                    return null;
+                }
+
+                @Override
+                public CompletableFuture<Void> delete(Transaction transaction, String namespace, String entity, String id, ZonedDateTime version, PersistenceDeletePolicy policy) throws PersistenceException {
+                    return null;
+                }
+
+                @Override
+                public CompletableFuture<Void> deleteAllVersions(Transaction transaction, String namespace, String entity, String id, PersistenceDeletePolicy policy) throws PersistenceException {
+                    return null;
+                }
+
+                @Override
+                public CompletableFuture<Void> markDeleted(Transaction transaction, String namespace, String entity, String id, ZonedDateTime version, PersistenceDeletePolicy policy) throws PersistenceException {
+                    return null;
+                }
+
+                @Override
+                public Flow.Publisher<Fragment> findAll(Transaction transaction, ZonedDateTime snapshot, String namespace, String entity, String firstId, int limit) throws PersistenceException {
+                    return null;
+                }
+
+                @Override
+                public Flow.Publisher<Fragment> find(Transaction transaction, ZonedDateTime snapshot, String namespace, String entity, String path, byte[] value, String firstId, int limit) throws PersistenceException {
+                    return null;
+                }
+
+                @Override
+                public void close() throws PersistenceException {
+
+                }
+            };
         }
 
         @Override


### PR DESCRIPTION
### Add pagination to the relations in the graphql module

Pagination in GraphQL can be implemented in many way. I chose to use the relay style as it is a fair balance between complexity and functionality. A good explanation has been made by [apollo](https://blog.apollographql.com/explaining-graphql-connections-c48b7c3d6976). Relay connection is also backed by a neat [specification](https://facebook.github.io/relay/graphql/connections.htm).

A couple of uncertainties are still to be cleared: 
- Streaming cannot be implemented unless the persistence API either supports pagination itself or the identifiers of the related entities are moved from the source to the target - in which case we could probably use the search API (@kimcs can we look into this?).
- Without streaming, ordering must be consistent between calls.
- There's no difference btw relation and embedded domain objects from the GraphQL user standpoint. We might want for the users to be able to avoid using pagination altogether by providing default values but that is not specified in the spec.

**This pull request is not done yet.** Feel free to comment if something comes to mind. Here's a list of things I'll continue to work on:

- [x] Create fetcher that respects the relay style pagination for **relations**
- [x] Create fetcher that respects the relay style pagination for **root nodes**
- [x] Change the graph schema so that it creates the connection and edge types on the fly
- [x] Migrate to the connection-based fetcher on root nodes
- [x] Migrate to the connection-based fetcher on relations
- [ ] Fail fast when using reserved type `*Connection` and `PageInfo`
- [x] Implement streaming