### PR TITLE
Returns empty results instead of 4xx error on domain list endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>no.ssb.lds</groupId>
             <artifactId>linked-data-store-persistence-provider-memory</artifactId>
-            <version>0.6</version>
+            <version>0.7-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/no/ssb/lds/core/controller/DataController.java
+++ b/src/main/java/no/ssb/lds/core/controller/DataController.java
@@ -3,6 +3,7 @@ package no.ssb.lds.core.controller;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
+import io.undertow.util.StatusCodes;
 import no.ssb.lds.api.persistence.reactivex.RxJsonPersistence;
 import no.ssb.lds.api.specification.Specification;
 import no.ssb.lds.core.domain.embedded.EmbeddedResourceHandler;
@@ -60,7 +61,7 @@ class DataController implements HttpHandler {
                 try {
                     timestamp = ZonedDateTime.parse(timestampParam); // ISO-8601
                 } catch (DateTimeParseException e) {
-                    exchange.setStatusCode(400);
+                    exchange.setStatusCode(StatusCodes.BAD_REQUEST);
                     exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
                     exchange.getResponseSender().send("The 'timestamp' query-parameter must follow the ISO-8601 standard. Example of a valid formatted timestamp is '2018-12-06T11:05:31.000+01:00'");
                     return;
@@ -69,7 +70,7 @@ class DataController implements HttpHandler {
             }
             resourceContext = ResourceContext.createResourceContext(specification, exchange.getRelativePath(), timestamp);
         } catch (ResourceException e) {
-            exchange.setStatusCode(400);
+            exchange.setStatusCode(StatusCodes.BAD_REQUEST);
             exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
             exchange.getResponseSender().send(e.getMessage());
             return;
@@ -94,7 +95,7 @@ class DataController implements HttpHandler {
             return;
         }
 
-        exchange.setStatusCode(404);
+        exchange.setStatusCode(StatusCodes.NOT_FOUND);
         exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
         exchange.getResponseSender().send("Unsupported resource path: " + exchange.getRequestPath());
     }

--- a/src/main/java/no/ssb/lds/core/domain/managed/ManagedResourceHandler.java
+++ b/src/main/java/no/ssb/lds/core/domain/managed/ManagedResourceHandler.java
@@ -26,7 +26,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Deque;
 import java.util.LinkedList;
+import java.util.Map;
 
 import static no.ssb.lds.api.persistence.json.JsonTools.mapper;
 
@@ -144,7 +146,10 @@ public class ManagedResourceHandler implements HttpHandler {
                         return;
                     }
 
-                    boolean sync = exchange.getQueryParameters().getOrDefault("sync", new LinkedList()).stream().anyMatch(s -> "true".equalsIgnoreCase((String) s));
+                    // True if defined and no false values.
+                    Map<String, Deque<String>> parameters = exchange.getQueryParameters();
+                    boolean sync = parameters.getOrDefault("sync", new LinkedList<>())
+                            .stream().noneMatch("false"::equalsIgnoreCase);
 
                     Saga saga = sagaRepository.get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
 

--- a/src/main/java/no/ssb/lds/core/domain/managed/ManagedResourceHandler.java
+++ b/src/main/java/no/ssb/lds/core/domain/managed/ManagedResourceHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
+import io.undertow.util.StatusCodes;
 import no.ssb.concurrent.futureselector.SelectableFuture;
 import no.ssb.lds.api.persistence.Transaction;
 import no.ssb.lds.api.persistence.json.JsonDocument;
@@ -74,39 +75,33 @@ public class ManagedResourceHandler implements HttpHandler {
 
         boolean isManagedList = topLevelElement.id() == null;
 
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json; charset=utf-8");
+
         if (isManagedList && exchange.getQueryParameters().containsKey("schema")) {
             String jsonSchema = schemaRepository.getJsonSchema().getSchemaJson(resourceContext.getFirstElement().name());
-            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json; charset=utf-8");
             exchange.getResponseSender().send(jsonSchema, StandardCharsets.UTF_8);
             return;
         }
 
-        ArrayNode output = mapper.createArrayNode();
         try (Transaction tx = persistence.createTransaction(true)) {
             if (isManagedList) {
                 Iterable<JsonDocument> documents = persistence.readDocuments(tx, resourceContext.getTimestamp(), resourceContext.getNamespace(), topLevelElement.name(), Range.unbounded()).blockingIterable();
+                ArrayNode output = mapper.createArrayNode();
                 for (JsonDocument jsonDocument : documents) {
                     if (jsonDocument.deleted()) {
                         continue;
                     }
                     output.add(jsonDocument.jackson());
                 }
+                exchange.getResponseSender().send(JsonTools.toJson(output), StandardCharsets.UTF_8);
             } else {
                 JsonDocument jsonDocument = persistence.readDocument(tx, resourceContext.getTimestamp(), resourceContext.getNamespace(), topLevelElement.name(), topLevelElement.id()).blockingGet();
                 if (jsonDocument != null && !jsonDocument.deleted()) {
-                    output.add(jsonDocument.jackson());
+                    exchange.getResponseSender().send(JsonTools.toJson(jsonDocument.jackson()), StandardCharsets.UTF_8);
+                } else {
+                    exchange.setStatusCode(StatusCodes.NOT_FOUND);
                 }
             }
-        }
-        if (output.size() == 0) {
-            exchange.setStatusCode(404);
-        } else if (output.size() == 1) {
-            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json; charset=utf-8");
-            exchange.getResponseSender().send(JsonTools.toJson(output.get(0)), StandardCharsets.UTF_8);
-        } else {
-            // (output.length() > 1
-            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json; charset=utf-8");
-            exchange.getResponseSender().send(JsonTools.toJson(output), StandardCharsets.UTF_8);
         }
         exchange.endExchange();
     }
@@ -157,12 +152,12 @@ public class ManagedResourceHandler implements HttpHandler {
                     SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, namespace, managedDomain, managedDocumentId, resourceContext.getTimestamp(), requestData);
                     SagaHandoffResult handoffResult = handoff.join();
 
-                    exchange.setStatusCode(200);
+                    exchange.setStatusCode(StatusCodes.CREATED);
                     exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
                     exchange.getResponseSender().send("{\"saga-execution-id\":\"" + handoffResult.executionId + "\"}");
                 },
                 (exchange1, e) -> {
-                    exchange.setStatusCode(500);
+                    exchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR);
                     exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
                     exchange.getResponseSender().send("Error: " + e.getMessage());
                     LOG.warn("", e);
@@ -174,7 +169,9 @@ public class ManagedResourceHandler implements HttpHandler {
         ResourceElement topLevelElement = resourceContext.getFirstElement();
         String managedDomain = topLevelElement.name();
 
-        boolean sync = exchange.getQueryParameters().getOrDefault("sync", new LinkedList()).stream().anyMatch(s -> "true".equalsIgnoreCase((String) s));
+        boolean sync = exchange.getQueryParameters()
+                .getOrDefault("sync", new LinkedList<>())
+                .stream().anyMatch(s -> "true".equalsIgnoreCase(s));
 
         Saga saga = sagaRepository.get(SagaRepository.SAGA_DELETE_MANAGED_RESOURCE);
 
@@ -182,7 +179,7 @@ public class ManagedResourceHandler implements HttpHandler {
         SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, resourceContext.getNamespace(), managedDomain, topLevelElement.id(), resourceContext.getTimestamp(), null);
         SagaHandoffResult handoffResult = handoff.join();
 
-        exchange.setStatusCode(200);
+        exchange.setStatusCode(StatusCodes.NO_CONTENT);
         exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
         exchange.getResponseSender().send("{\"saga-execution-id\":\"" + handoffResult.executionId + "\"}");
     }

--- a/src/test/java/no/ssb/lds/core/controller/DataControllerTest.java
+++ b/src/test/java/no/ssb/lds/core/controller/DataControllerTest.java
@@ -1,12 +1,24 @@
 package no.ssb.lds.core.controller;
 
+import io.undertow.util.Headers;
+import io.undertow.util.StatusCodes;
 import no.ssb.lds.test.client.TestClient;
+import no.ssb.lds.test.server.TestServer;
 import no.ssb.lds.test.server.TestServerListener;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
+import java.io.IOException;
 
+import static no.ssb.lds.core.utils.FileAndClasspathReaderUtils.readFileOrClasspathResource;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 @Listeners(TestServerListener.class)
@@ -14,6 +26,76 @@ public class DataControllerTest {
 
     @Inject
     private TestClient client;
+
+    @Inject
+    private TestServer server;
+
+    private OkHttpClient okHttpClient = new OkHttpClient();
+    private Request.Builder request = new Request.Builder();
+
+    private HttpUrl.Builder newUrl() {
+        return new HttpUrl.Builder().scheme("http").host(server.getTestServerHost())
+                .port(server.getTestServerServicePort());
+    }
+
+    @Test
+    public void testGetEmptyDomainList() throws IOException {
+        HttpUrl listContactUrl = newUrl().addPathSegments("/data/contact").build();
+        Request listContactRequest = request.url(listContactUrl).build();
+        try (Response response = okHttpClient.newCall(listContactRequest).execute()) {
+            assertThat(response.code())
+                    .as("response code of %s", listContactUrl)
+                    .isEqualTo(StatusCodes.OK);
+        }
+    }
+
+    @Test
+    public void testPutDomain() throws IOException {
+        HttpUrl putContact = newUrl().addPathSegments("data/contact/donald").build();
+
+        RequestBody body = RequestBody.create(
+                MediaType.get("application/json"),
+                readFileOrClasspathResource("demo/4-donald.json")
+        );
+
+        Request listContactRequest = request.url(putContact).put(body).build();
+        try (Response response = okHttpClient.newCall(listContactRequest).execute()) {
+            assertThat(response.code())
+                    .as("response code of %s", putContact)
+                    .isEqualTo(StatusCodes.CREATED);
+        }
+    }
+
+    @Test(dependsOnMethods = "testPutDomain")
+    public void testGetDomainList() throws IOException {
+        HttpUrl putContact = newUrl().addPathSegments("data/contact").build();
+        Request listContactRequest = request.url(putContact).get().build();
+        try (Response response = okHttpClient.newCall(listContactRequest).execute()) {
+            assertThat(response.code())
+                    .as("response code in response to %s", putContact)
+                    .isEqualTo(StatusCodes.OK);
+            assertThat(response.header(Headers.CONTENT_TYPE_STRING))
+                    .as("content type header in response to %s", putContact)
+                    .startsWith("application/json");
+            assertThat(response.body().string()).isEqualTo("");
+        }
+    }
+
+    @Test(dependsOnMethods = "testPutDomain")
+    public void testGetDomain() throws IOException {
+        HttpUrl getContact = newUrl().addPathSegments("data/contact/donald").build();
+        Request listContactRequest = request.url(getContact).get().build();
+        try (Response response = okHttpClient.newCall(listContactRequest).execute()) {
+            assertThat(response.code())
+                    .as("response code of %s", getContact)
+                    .isEqualTo(StatusCodes.OK);
+            assertThat(response.header(Headers.CONTENT_TYPE_STRING))
+                    .as("content type header in response to %s", getContact)
+                    .startsWith("application/json");
+            assertThat(response.body().string())
+                    .as("body in response to %s").isEqualTo("");
+        }
+    }
 
     @Test
     public void thatGETWithIllegalRequestPathFailsWith400() {

--- a/src/test/java/no/ssb/lds/test/server/TestServerListener.java
+++ b/src/test/java/no/ssb/lds/test/server/TestServerListener.java
@@ -152,7 +152,7 @@ public class TestServerListener implements ITestListener, IInvokedMethodListener
         boolean injectableTestClassFieldsInvalidated = false;
         if (testclassHistory.remove(method.getTestMethod().getTestClass().getRealClass().getName())) {
             injectableTestClassFieldsInvalidated = true;
-            LOG.info("Invalidating injected varaibles for: {}.{}", method.getTestMethod().getTestClass().getRealClass().getName(), method.getTestMethod().getMethodName());
+            LOG.info("Invalidating injected variables for: {}.{}", method.getTestMethod().getTestClass().getRealClass().getName(), method.getTestMethod().getMethodName());
         }
         String previousTestClazz = currentTestClazz.get();
         if (!method.getTestMethod().getTestClass().getRealClass().getName().equals(previousTestClazz)) {


### PR DESCRIPTION
When using the list endpoint `GET /[namespace]/[domain]` on an empty database, the core 
module returns a 404 HTTP error code. 

This PR make the endpoint returns a 200 OK with an empty json array instead.

This was reported on https://jira.ssb.no/browse/LDS-158