### PR TITLE
Added Saga commands feature

### DIFF
--- a/src/main/java/no/ssb/lds/core/UndertowApplication.java
+++ b/src/main/java/no/ssb/lds/core/UndertowApplication.java
@@ -206,7 +206,9 @@ public class UndertowApplication {
         );
         int numberOfSagaLogs = configuration.evaluateToInt("saga.number-of-logs");
 
-        SagaExecutionCoordinator sec = new SagaExecutionCoordinator(sagaLogPool, numberOfSagaLogs, sagaRepository, sagasObserver, sagaThreadPool);
+        boolean sagaCommandsEnabled = configuration.evaluateToBoolean("saga.commands.enabled");
+
+        SagaExecutionCoordinator sec = new SagaExecutionCoordinator(sagaLogPool, numberOfSagaLogs, sagaRepository, sagasObserver, sagaThreadPool, sagaCommandsEnabled);
 
         HystrixThreadPoolProperties.Setter().withMaximumSize(50); // TODO Configure Hystrix properly
 

--- a/src/main/java/no/ssb/lds/core/domain/embedded/EmbeddedResourceHandler.java
+++ b/src/main/java/no/ssb/lds/core/domain/embedded/EmbeddedResourceHandler.java
@@ -12,6 +12,7 @@ import no.ssb.lds.api.persistence.reactivex.RxJsonPersistence;
 import no.ssb.lds.api.specification.Specification;
 import no.ssb.lds.core.domain.resource.ResourceContext;
 import no.ssb.lds.core.domain.resource.ResourceElement;
+import no.ssb.lds.core.saga.SagaCommands;
 import no.ssb.lds.core.saga.SagaExecutionCoordinator;
 import no.ssb.lds.core.saga.SagaRepository;
 import no.ssb.lds.core.schema.SchemaRepository;
@@ -140,7 +141,7 @@ public class EmbeddedResourceHandler implements HttpHandler {
                     Saga saga = sagaRepository.get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
 
                     AdapterLoader adapterLoader = sagaRepository.getAdapterLoader();
-                    SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, namespace, managedDomain, managedDocumentId, resourceContext.getTimestamp(), managedDocument);
+                    SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, namespace, managedDomain, managedDocumentId, resourceContext.getTimestamp(), managedDocument, SagaCommands.getSagaAdminParameterCommands(httpServerExchange));
                     SagaHandoffResult handoffResult = handoff.join();
 
                     exchange.setStatusCode(200);
@@ -181,7 +182,7 @@ public class EmbeddedResourceHandler implements HttpHandler {
                     Saga saga = sagaRepository.get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
 
                     AdapterLoader adapterLoader = sagaRepository.getAdapterLoader();
-                    SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, namespace, managedDomain, managedDocumentId, resourceContext.getTimestamp(), rootNode);
+                    SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, namespace, managedDomain, managedDocumentId, resourceContext.getTimestamp(), rootNode, SagaCommands.getSagaAdminParameterCommands(httpServerExchange));
                     SagaHandoffResult handoffResult = handoff.join();
 
                     exchange.setStatusCode(200);

--- a/src/main/java/no/ssb/lds/core/domain/managed/ManagedResourceHandler.java
+++ b/src/main/java/no/ssb/lds/core/domain/managed/ManagedResourceHandler.java
@@ -16,6 +16,7 @@ import no.ssb.lds.api.persistence.reactivex.RxJsonPersistence;
 import no.ssb.lds.api.specification.Specification;
 import no.ssb.lds.core.domain.resource.ResourceContext;
 import no.ssb.lds.core.domain.resource.ResourceElement;
+import no.ssb.lds.core.saga.SagaCommands;
 import no.ssb.lds.core.saga.SagaExecutionCoordinator;
 import no.ssb.lds.core.saga.SagaRepository;
 import no.ssb.lds.core.schema.SchemaRepository;
@@ -158,7 +159,7 @@ public class ManagedResourceHandler implements HttpHandler {
                     Saga saga = sagaRepository.get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
 
                     AdapterLoader adapterLoader = sagaRepository.getAdapterLoader();
-                    SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, namespace, managedDomain, managedDocumentId, resourceContext.getTimestamp(), requestData);
+                    SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, namespace, managedDomain, managedDocumentId, resourceContext.getTimestamp(), requestData, SagaCommands.getSagaAdminParameterCommands(httpServerExchange));
                     SagaHandoffResult handoffResult = handoff.join();
 
                     exchange.setStatusCode(StatusCodes.CREATED);
@@ -186,7 +187,7 @@ public class ManagedResourceHandler implements HttpHandler {
         Saga saga = sagaRepository.get(SagaRepository.SAGA_DELETE_MANAGED_RESOURCE);
 
         AdapterLoader adapterLoader = sagaRepository.getAdapterLoader();
-        SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, resourceContext.getNamespace(), managedDomain, topLevelElement.id(), resourceContext.getTimestamp(), null);
+        SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, resourceContext.getNamespace(), managedDomain, topLevelElement.id(), resourceContext.getTimestamp(), null, SagaCommands.getSagaAdminParameterCommands(exchange));
         SagaHandoffResult handoffResult = handoff.join();
 
         HeaderMap responseHeaders = exchange.getResponseHeaders();

--- a/src/main/java/no/ssb/lds/core/domain/reference/ReferenceResourceHandler.java
+++ b/src/main/java/no/ssb/lds/core/domain/reference/ReferenceResourceHandler.java
@@ -12,6 +12,7 @@ import no.ssb.lds.api.persistence.reactivex.RxJsonPersistence;
 import no.ssb.lds.api.specification.Specification;
 import no.ssb.lds.core.domain.resource.ResourceContext;
 import no.ssb.lds.core.domain.resource.ResourceElement;
+import no.ssb.lds.core.saga.SagaCommands;
 import no.ssb.lds.core.saga.SagaExecutionCoordinator;
 import no.ssb.lds.core.saga.SagaRepository;
 import no.ssb.saga.api.Saga;
@@ -108,7 +109,7 @@ public class ReferenceResourceHandler implements HttpHandler {
                         Saga saga = sagaRepository.get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
 
                         AdapterLoader adapterLoader = sagaRepository.getAdapterLoader();
-                        SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, namespace, managedDomain, managedDocumentId, resourceContext.getTimestamp(), jsonDocument.jackson());
+                        SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, namespace, managedDomain, managedDocumentId, resourceContext.getTimestamp(), jsonDocument.jackson(), SagaCommands.getSagaAdminParameterCommands(httpServerExchange));
                         SagaHandoffResult sagaHandoffResult = handoff.join();
 
                         exchange.setStatusCode(200);
@@ -162,7 +163,7 @@ public class ReferenceResourceHandler implements HttpHandler {
         Saga saga = sagaRepository.get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
 
         AdapterLoader adapterLoader = sagaRepository.getAdapterLoader();
-        SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, resourceContext.getNamespace(), resourceContext.getFirstElement().name(), resourceContext.getFirstElement().id(), resourceContext.getTimestamp(), rootNode);
+        SelectableFuture<SagaHandoffResult> handoff = sec.handoff(sync, adapterLoader, saga, resourceContext.getNamespace(), resourceContext.getFirstElement().name(), resourceContext.getFirstElement().id(), resourceContext.getTimestamp(), rootNode, SagaCommands.getSagaAdminParameterCommands(exchange));
         SagaHandoffResult handoffResult = handoff.join();
 
         if (sync) {

--- a/src/main/java/no/ssb/lds/core/saga/SagaCommand.java
+++ b/src/main/java/no/ssb/lds/core/saga/SagaCommand.java
@@ -1,0 +1,27 @@
+package no.ssb.lds.core.saga;
+
+import java.util.List;
+
+public class SagaCommand {
+    private final String nodeId;
+    private final String command;
+    private final List<String> arguments;
+
+    public SagaCommand(String nodeId, String command, List<String> arguments) {
+        this.nodeId = nodeId;
+        this.command = command;
+        this.arguments = arguments;
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public List<String> getArguments() {
+        return arguments;
+    }
+}

--- a/src/main/java/no/ssb/lds/core/saga/SagaCommands.java
+++ b/src/main/java/no/ssb/lds/core/saga/SagaCommands.java
@@ -1,0 +1,35 @@
+package no.ssb.lds.core.saga;
+
+import io.undertow.server.HttpServerExchange;
+
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class SagaCommands {
+
+    public static Map<String, List<SagaCommand>> getSagaAdminParameterCommands(HttpServerExchange exchange) {
+        Deque<String> sagaCommands = exchange.getQueryParameters().get("saga");
+        if (sagaCommands == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, List<SagaCommand>> map = new LinkedHashMap<>();
+        for (String sagaCommand : sagaCommands) {
+            String[] parts = sagaCommand.split("\\s");
+            if (parts.length < 2) {
+                continue;
+            }
+            String command = parts[0];
+            String nodeId = parts[1];
+            List<String> args = new LinkedList<>();
+            for (int i = 2; i < parts.length; i++) {
+                args.add(parts[i]);
+            }
+            map.computeIfAbsent(nodeId, n -> new LinkedList<>()).add(new SagaCommand(nodeId, command, args));
+        }
+        return map;
+    }
+}

--- a/src/main/resources/application-defaults.properties
+++ b/src/main/resources/application-defaults.properties
@@ -47,6 +47,8 @@ saga.recovery.enabled=true
 saga.recovery.interval.seconds.min=30
 saga.recovery.interval.seconds.max=60
 
+saga.commands.enabled=false
+
 specification.schema=
 
 graphql.enabled=true

--- a/src/test/java/no/ssb/lds/core/saga/SagaCommandTest.java
+++ b/src/test/java/no/ssb/lds/core/saga/SagaCommandTest.java
@@ -1,0 +1,30 @@
+package no.ssb.lds.core.saga;
+
+import no.ssb.lds.test.ConfigurationOverride;
+import no.ssb.lds.test.client.TestClient;
+import no.ssb.lds.test.server.TestServerListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+@Listeners(TestServerListener.class)
+public class SagaCommandTest {
+
+    @Inject
+    private TestClient client;
+
+    @Test
+    @ConfigurationOverride({"saga.commands.enabled", "false"})
+    public void thatFailCommandDoesNotWorkWhenSagaCommandDisabled() {
+        String body = "{\"name\":\"pa-test-name\",\"contacts\":[\"/contact/c1\",\"/contact/c2\"]}";
+        client.put(String.format("/data/provisionagreement/m1?%s&%s", "sync=true", "saga=failBefore%20E"), body).expect201Created();
+    }
+
+    @Test
+    @ConfigurationOverride({"saga.commands.enabled", "true"})
+    public void thatFailCommandWorksWhenSagaCommandEnabled() {
+        String body = "{\"name\":\"pa-test-name\",\"contacts\":[\"/contact/c1\",\"/contact/c2\"]}";
+        client.put(String.format("/data/provisionagreement/m1?%s&%s", "sync=true", "saga=failBefore%20E"), body).expectAnyOf(500);
+    }
+}

--- a/src/test/java/no/ssb/lds/core/saga/SagaRecoveryTriggerTest.java
+++ b/src/test/java/no/ssb/lds/core/saga/SagaRecoveryTriggerTest.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 
 import javax.inject.Inject;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,7 +42,7 @@ public class SagaRecoveryTriggerTest {
         sec.sagaRepository.register(saga);
         SagaLogPool sagaLogPool = sec.getSagaLogPool();
         SelectableFuture<SagaHandoffResult> handoff = sec.handoff(true, sec.sagaRepository.getAdapterLoader(), saga,
-                "ns", "SomeEntity", "x123", ZonedDateTime.now(), JsonTools.mapper.createObjectNode());
+                "ns", "SomeEntity", "x123", ZonedDateTime.now(), JsonTools.mapper.createObjectNode(), Collections.emptyMap());
         try {
             handoff.join(); // wait for saga-execution to fail
             Assert.fail("Saga execution did no fail on first attempt");
@@ -80,7 +81,7 @@ public class SagaRecoveryTriggerTest {
     static class FailingTheFirstTimeSagaAdapter extends Adapter<String> {
         final AtomicInteger attempts = new AtomicInteger();
 
-        public FailingTheFirstTimeSagaAdapter() {
+        FailingTheFirstTimeSagaAdapter() {
             super(String.class, "zigzag");
         }
 


### PR DESCRIPTION
This feature allows the user to specify failBefore or failAfter saga commands using "saga" query parameter. This will force the saga-execution to fail at specified point during saga-execution and request fails with error code 500.