### PR TITLE
Feature/restore from tx log

### DIFF
--- a/src/main/java/no/ssb/lds/core/controller/NamespaceController.java
+++ b/src/main/java/no/ssb/lds/core/controller/NamespaceController.java
@@ -5,6 +5,8 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import no.ssb.lds.api.persistence.reactivex.RxJsonPersistence;
 import no.ssb.lds.api.specification.Specification;
+import no.ssb.lds.core.restore.RestoreContextBySource;
+import no.ssb.lds.core.restore.RestoreHandler;
 import no.ssb.lds.core.saga.SagaExecutionCoordinator;
 import no.ssb.lds.core.saga.SagaRepository;
 import no.ssb.lds.core.schema.SchemaRepository;
@@ -24,6 +26,7 @@ public class NamespaceController implements HttpHandler {
     private final SagaExecutionCoordinator sec;
     private final SagaRepository sagaRepository;
     private final TxlogRawdataPool txLogPool;
+    private final RestoreContextBySource restoreContextBySource;
 
     public NamespaceController(String namespaceDefault, Specification specification, SchemaRepository schemaRepository,
                                RxJsonPersistence persistence, SagaExecutionCoordinator sec,
@@ -38,6 +41,7 @@ public class NamespaceController implements HttpHandler {
         }
         this.defaultNamespace = namespaceDefault;
         this.sec = sec;
+        this.restoreContextBySource = new RestoreContextBySource();
     }
 
     @Override
@@ -71,6 +75,11 @@ public class NamespaceController implements HttpHandler {
 
         if (requestPath.startsWith("/source/")) {
             new SourceHandler(txLogPool).handleRequest(exchange);
+            return;
+        }
+
+        if (requestPath.startsWith("/restore/")) {
+            new RestoreHandler(restoreContextBySource, txLogPool, sec).handleRequest(exchange);
             return;
         }
 

--- a/src/main/java/no/ssb/lds/core/domain/embedded/EmbeddedResourceHandler.java
+++ b/src/main/java/no/ssb/lds/core/domain/embedded/EmbeddedResourceHandler.java
@@ -145,7 +145,13 @@ public class EmbeddedResourceHandler implements HttpHandler {
 
                     boolean sync = exchange.getQueryParameters().getOrDefault("sync", new LinkedList()).stream().anyMatch(s -> "true".equalsIgnoreCase((String) s));
 
-                    Saga saga = sagaRepository.get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
+                    boolean noTxLogging = ofNullable(exchange.getQueryParameters().get("notxlog"))
+                            .map(Deque::peekFirst)
+                            .map(Boolean::valueOf)
+                            .orElse(Boolean.FALSE);
+                    Saga saga = sagaRepository.get(noTxLogging ?
+                            SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE_NO_TX_LOG :
+                            SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
 
                     String source = ofNullable(exchange.getQueryParameters().get("source")).map(Deque::peekFirst).orElse(null);
                     String sourceId = ofNullable(exchange.getQueryParameters().get("sourceId")).map(Deque::peekFirst).orElse(null);
@@ -190,7 +196,13 @@ public class EmbeddedResourceHandler implements HttpHandler {
 
                     boolean sync = exchange.getQueryParameters().getOrDefault("sync", new LinkedList()).stream().anyMatch(s -> "true".equalsIgnoreCase((String) s));
 
-                    Saga saga = sagaRepository.get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
+                    boolean noTxLogging = ofNullable(exchange.getQueryParameters().get("notxlog"))
+                            .map(Deque::peekFirst)
+                            .map(Boolean::valueOf)
+                            .orElse(Boolean.FALSE);
+                    Saga saga = sagaRepository.get(noTxLogging ?
+                            SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE_NO_TX_LOG :
+                            SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
 
                     String source = ofNullable(exchange.getQueryParameters().get("source")).map(Deque::peekFirst).orElse(null);
                     String sourceId = ofNullable(exchange.getQueryParameters().get("sourceId")).map(Deque::peekFirst).orElse(null);

--- a/src/main/java/no/ssb/lds/core/domain/managed/ManagedResourceHandler.java
+++ b/src/main/java/no/ssb/lds/core/domain/managed/ManagedResourceHandler.java
@@ -180,7 +180,13 @@ public class ManagedResourceHandler implements HttpHandler {
                     boolean sync = parameters.getOrDefault("sync", new LinkedList<>())
                             .stream().noneMatch("false"::equalsIgnoreCase);
 
-                    Saga saga = sagaRepository.get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
+                    boolean noTxLogging = ofNullable(exchange.getQueryParameters().get("notxlog"))
+                            .map(Deque::peekFirst)
+                            .map(Boolean::valueOf)
+                            .orElse(Boolean.FALSE);
+                    Saga saga = sagaRepository.get(noTxLogging ?
+                            SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE_NO_TX_LOG :
+                            SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
 
                     String source = ofNullable(exchange.getQueryParameters().get("source")).map(Deque::peekFirst).orElse(null);
                     String sourceId = ofNullable(exchange.getQueryParameters().get("sourceId")).map(Deque::peekFirst).orElse(null);
@@ -212,7 +218,13 @@ public class ManagedResourceHandler implements HttpHandler {
         boolean sync = parameters.getOrDefault("sync", new LinkedList<>())
                 .stream().noneMatch("false"::equalsIgnoreCase);
 
-        Saga saga = sagaRepository.get(SagaRepository.SAGA_DELETE_MANAGED_RESOURCE);
+        boolean noTxLogging = ofNullable(exchange.getQueryParameters().get("notxlog"))
+                .map(Deque::peekFirst)
+                .map(Boolean::valueOf)
+                .orElse(Boolean.FALSE);
+        Saga saga = sagaRepository.get(noTxLogging ?
+                SagaRepository.SAGA_DELETE_MANAGED_RESOURCE_NO_TX_LOG :
+                SagaRepository.SAGA_DELETE_MANAGED_RESOURCE);
 
         String source = ofNullable(exchange.getQueryParameters().get("source")).map(Deque::peekFirst).orElse(null);
         String sourceId = ofNullable(exchange.getQueryParameters().get("sourceId")).map(Deque::peekFirst).orElse(null);

--- a/src/main/java/no/ssb/lds/core/domain/reference/ReferenceResourceHandler.java
+++ b/src/main/java/no/ssb/lds/core/domain/reference/ReferenceResourceHandler.java
@@ -109,7 +109,13 @@ public class ReferenceResourceHandler implements HttpHandler {
 
                         boolean sync = exchange.getQueryParameters().getOrDefault("sync", new LinkedList<>()).stream().anyMatch(s -> "true".equalsIgnoreCase(s));
 
-                        Saga saga = sagaRepository.get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
+                        boolean noTxLogging = ofNullable(exchange.getQueryParameters().get("notxlog"))
+                                .map(Deque::peekFirst)
+                                .map(Boolean::valueOf)
+                                .orElse(Boolean.FALSE);
+                        Saga saga = sagaRepository.get(noTxLogging ?
+                                SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE_NO_TX_LOG :
+                                SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
 
                         String source = ofNullable(exchange.getQueryParameters().get("source")).map(Deque::peekFirst).orElse(null);
                         String sourceId = ofNullable(exchange.getQueryParameters().get("sourceId")).map(Deque::peekFirst).orElse(null);
@@ -167,7 +173,13 @@ public class ReferenceResourceHandler implements HttpHandler {
 
         boolean sync = exchange.getQueryParameters().getOrDefault("sync", new LinkedList()).stream().anyMatch(s -> "true".equalsIgnoreCase((String) s));
 
-        Saga saga = sagaRepository.get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
+        boolean noTxLogging = ofNullable(exchange.getQueryParameters().get("notxlog"))
+                .map(Deque::peekFirst)
+                .map(Boolean::valueOf)
+                .orElse(Boolean.FALSE);
+        Saga saga = sagaRepository.get(noTxLogging ?
+                SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE_NO_TX_LOG :
+                SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE);
 
         String source = ofNullable(exchange.getQueryParameters().get("source")).map(Deque::peekFirst).orElse(null);
         String sourceId = ofNullable(exchange.getQueryParameters().get("sourceId")).map(Deque::peekFirst).orElse(null);

--- a/src/main/java/no/ssb/lds/core/restore/ConcurrentRestoreStartException.java
+++ b/src/main/java/no/ssb/lds/core/restore/ConcurrentRestoreStartException.java
@@ -1,0 +1,4 @@
+package no.ssb.lds.core.restore;
+
+public class ConcurrentRestoreStartException extends RuntimeException {
+}

--- a/src/main/java/no/ssb/lds/core/restore/RestoreContext.java
+++ b/src/main/java/no/ssb/lds/core/restore/RestoreContext.java
@@ -1,0 +1,161 @@
+package no.ssb.lds.core.restore;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import de.huxhorn.sulky.ulid.ULID;
+import no.ssb.concurrent.futureselector.SelectableFuture;
+import no.ssb.lds.api.persistence.json.JsonTools;
+import no.ssb.lds.core.saga.SagaExecutionCoordinator;
+import no.ssb.lds.core.saga.SagaInput;
+import no.ssb.lds.core.saga.SagaRepository;
+import no.ssb.lds.core.txlog.TxLogTools;
+import no.ssb.lds.core.txlog.TxlogRawdataPool;
+import no.ssb.rawdata.api.RawdataConsumer;
+import no.ssb.rawdata.api.RawdataMessage;
+import no.ssb.saga.api.Saga;
+import no.ssb.saga.execution.SagaHandoffResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.util.Optional.ofNullable;
+
+public class RestoreContext {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RestoreContext.class);
+
+    private final SagaExecutionCoordinator sec;
+
+    private final TxlogRawdataPool txLogPool;
+    private final Thread workerThread;
+    private final String source;
+    private final ULID.Value fromTxId;
+    private final boolean fromInclusive;
+    private final ULID.Value toTxId;
+    private final boolean toInclusive;
+    private final RawdataMessage lastMessage;
+    private final AtomicBoolean hasStarted = new AtomicBoolean();
+    private final AtomicBoolean stopped = new AtomicBoolean();
+    private final AtomicBoolean done = new AtomicBoolean();
+    private final AtomicLong messagesRestored = new AtomicLong();
+    private final AtomicLong messagesFailed = new AtomicLong();
+    private final AtomicLong messagesIgnored = new AtomicLong();
+
+    public RestoreContext(SagaExecutionCoordinator sec, TxlogRawdataPool txLogPool, String source, ULID.Value fromTxId, boolean fromInclusive, ULID.Value toTxId, boolean toInclusive) {
+        this.sec = sec;
+        this.txLogPool = txLogPool;
+        this.source = source;
+        this.fromTxId = fromTxId;
+        this.fromInclusive = fromInclusive;
+        this.toTxId = toTxId;
+        this.toInclusive = toInclusive;
+        this.workerThread = new Thread(new RestoreWorker());
+        this.lastMessage = txLogPool.getLastMessage(source);
+    }
+
+    RestoreContext restore() {
+        if (hasStarted.compareAndSet(false, true)) {
+            workerThread.start();
+        }
+        return this;
+    }
+
+    void stop() {
+        stopped.set(true);
+        workerThread.interrupt();
+    }
+
+    boolean hasStarted() {
+        return hasStarted.get();
+    }
+
+    boolean isDone() {
+        return done.get();
+    }
+
+    class RestoreWorker implements Runnable {
+        @Override
+        public void run() {
+            final String topic = txLogPool.topicOf(source);
+            try (RawdataConsumer consumer = txLogPool.getClient().consumer(topic, fromTxId, fromInclusive)) {
+                while (!stopped.get()) {
+                    RawdataMessage message;
+                    try {
+                        message = consumer.receive(10, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        continue;
+                    }
+                    if (stopped.get()) {
+                        break;
+                    }
+                    if (message == null) {
+                        break;
+                    }
+                    if (toTxId != null) {
+                        int comparison = message.ulid().compareTo(toTxId);
+                        if (comparison > 0 || (!toInclusive && (comparison == 0))) {
+                            return; // past upper bound set by client
+                        }
+                    }
+                    int comparisonWithLastMessage = message.ulid().compareTo(lastMessage.ulid());
+                    if (comparisonWithLastMessage > 0) {
+                        return; // past upper bound decided by lastMessage read at start of restore
+                    }
+                    Saga saga;
+                    SagaInput sagaInput = TxLogTools.txEntryToSagaInput(message);
+                    if ("DELETE".equalsIgnoreCase(sagaInput.method())) {
+                        saga = sec.getSagaRepository().get(SagaRepository.SAGA_DELETE_MANAGED_RESOURCE_NO_TX_LOG);
+                    } else if ("PUT".equalsIgnoreCase(sagaInput.method())) {
+                        saga = sec.getSagaRepository().get(SagaRepository.SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE_NO_TX_LOG);
+                    } else {
+                        LOG.warn("IGNORING message in txlog: ulid={}, method={}, entity={}, id={}, version={}", message.ulid().toString(), sagaInput.method(), sagaInput.entity(), sagaInput.resourceId(), sagaInput.versionAsString());
+                        messagesIgnored.incrementAndGet();
+                        if (comparisonWithLastMessage == 0) {
+                            return; // finished processing lastMessage
+                        }
+                        continue;
+                    }
+                    SelectableFuture<SagaHandoffResult> handoff = sec.handoff(true, sec.getSagaRepository().getAdapterLoader(), saga, sagaInput, Collections.emptyMap());
+                    SagaHandoffResult handoffResult = handoff.join();
+                    if (handoffResult.isSuccess()) {
+                        messagesRestored.incrementAndGet();
+                    } else {
+                        LOG.error(String.format("FAILED to process message: ulid=%s, method=%s, entity=%s, id=%s, version=%s", message.ulid().toString(), sagaInput.method(), sagaInput.entity(), sagaInput.resourceId(), sagaInput.versionAsString()), handoffResult.getFailureCause());
+                        messagesFailed.incrementAndGet();
+                    }
+                    if (comparisonWithLastMessage == 0) {
+                        return; // finished processing lastMessage
+                    }
+                }
+            } catch (Exception e) {
+                LOG.error("", e);
+            } finally {
+                done.set(true);
+            }
+        }
+    }
+
+    public JsonNode serializeContextState() {
+        ObjectNode ctx = JsonTools.mapper.createObjectNode();
+        ctx.put("source", source);
+        ctx.put("messagesRestored", messagesRestored.get());
+        ctx.put("messagesFailed", messagesFailed.get());
+        ctx.put("messagesIgnored", messagesIgnored.get());
+        ctx.put("done", done.get());
+        ctx.put("fromTxId", ofNullable(fromTxId).map(ULID.Value::toString).orElse(null));
+        ctx.put("fromInclusive", fromInclusive);
+        ctx.put("toTxId", ofNullable(toTxId).map(ULID.Value::toString).orElse(null));
+        ctx.put("toInclusive", toInclusive);
+        ctx.put("lastMessageTxId", ofNullable(lastMessage).map(RawdataMessage::ulid).map(ULID.Value::toString).orElse(null));
+        ctx.put("hasStarted", hasStarted.get());
+        ctx.put("stopped", stopped.get());
+        ObjectNode workerThreadObject = ctx.putObject("workerThread");
+        workerThreadObject.put("name", workerThread.getName());
+        workerThreadObject.put("state", workerThread.getState().name());
+        return ctx;
+    }
+}

--- a/src/main/java/no/ssb/lds/core/restore/RestoreContextBySource.java
+++ b/src/main/java/no/ssb/lds/core/restore/RestoreContextBySource.java
@@ -1,0 +1,9 @@
+package no.ssb.lds.core.restore;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class RestoreContextBySource {
+
+    final Map<String, RestoreContext> map = new ConcurrentHashMap<>();
+}

--- a/src/main/java/no/ssb/lds/core/restore/RestoreHandler.java
+++ b/src/main/java/no/ssb/lds/core/restore/RestoreHandler.java
@@ -1,0 +1,122 @@
+package no.ssb.lds.core.restore;
+
+import de.huxhorn.sulky.ulid.ULID;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import no.ssb.lds.api.persistence.json.JsonTools;
+import no.ssb.lds.core.saga.SagaExecutionCoordinator;
+import no.ssb.lds.core.txlog.TxlogRawdataPool;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Optional.ofNullable;
+
+public class RestoreHandler implements HttpHandler {
+
+    private final RestoreContextBySource restoreContextBySource;
+    private final TxlogRawdataPool txLogPool;
+    private final SagaExecutionCoordinator sec;
+
+    public RestoreHandler(RestoreContextBySource restoreContextBySource, TxlogRawdataPool txLogPool, SagaExecutionCoordinator sec) {
+        this.restoreContextBySource = restoreContextBySource;
+        this.txLogPool = txLogPool;
+        this.sec = sec;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        if (exchange.getRequestMethod().equalToString("get")) {
+            new RestoreHandler.GetHandler().handleRequest(exchange);
+            return;
+        }
+
+        if (exchange.getRequestMethod().equalToString("post")) {
+            new RestoreHandler.PostHandler().handleRequest(exchange);
+            return;
+        }
+
+        exchange.setStatusCode(400);
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
+        exchange.getResponseSender().send("Unsupported restore method: " + exchange.getRequestMethod());
+    }
+
+    private class GetHandler implements HttpHandler {
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            String source = exchange.getRequestPath().substring("/restore/".length());
+            RestoreContext context = restoreContextBySource.map.get(source);
+            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json; charset=utf-8");
+            exchange.getResponseSender().send(
+                    JsonTools.toJson(context == null ?
+                            JsonTools.mapper.createObjectNode() :
+                            context.serializeContextState()),
+                    StandardCharsets.UTF_8);
+        }
+    }
+
+    private class PostHandler implements HttpHandler {
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            if (exchange.isInIoThread()) {
+                exchange.dispatch(this);
+                return;
+            }
+
+            ULID.Value fromTxId = ofNullable(exchange.getQueryParameters().get("from"))
+                    .map(Deque::peek)
+                    .map(ULID::parseULID)
+                    .orElse(null);
+
+            boolean fromInclusive = ofNullable(exchange.getQueryParameters().get("fromInclusive"))
+                    .map(Deque::peek)
+                    .map(Boolean::valueOf)
+                    .orElse(Boolean.TRUE);
+
+            ULID.Value toTxId = ofNullable(exchange.getQueryParameters().get("to"))
+                    .map(Deque::peek)
+                    .map(ULID::parseULID)
+                    .orElse(null);
+
+            boolean toInclusive = ofNullable(exchange.getQueryParameters().get("toInclusive"))
+                    .map(Deque::peek)
+                    .map(Boolean::valueOf)
+                    .orElse(Boolean.TRUE);
+
+            String source = exchange.getRequestPath().substring("/restore/".length());
+            AtomicBoolean succeeded = new AtomicBoolean();
+            RestoreContext initialContext = restoreContextBySource.map.computeIfAbsent(source, s -> {
+                succeeded.set(true);
+                return new RestoreContext(sec, txLogPool, s, fromTxId, fromInclusive, toTxId, toInclusive)
+                        .restore();
+            });
+            RestoreContext restoreContext;
+            if (succeeded.get()) {
+                restoreContext = initialContext;
+            } else {
+                if (initialContext.isDone()) {
+                    // attempt to replace existing context with a new one
+                    try {
+                        restoreContext = restoreContextBySource.map.computeIfPresent(source, (s, oldCtx) -> {
+                            if (initialContext == oldCtx) {
+                                return new RestoreContext(sec, txLogPool, s, fromTxId, fromInclusive, toTxId, toInclusive)
+                                        .restore();
+                            } else {
+                                throw new ConcurrentRestoreStartException();
+                            }
+                        });
+                    } catch (ConcurrentRestoreStartException ce) {
+                        // another client started restore for this source concurrently and we lost the race
+                        restoreContext = restoreContextBySource.map.get(source);
+                    }
+                } else {
+                    restoreContext = initialContext;
+                }
+            }
+
+            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json; charset=utf-8");
+            exchange.getResponseSender().send(JsonTools.toJson(restoreContext.serializeContextState()), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/src/main/java/no/ssb/lds/core/saga/SagaExecutionCoordinator.java
+++ b/src/main/java/no/ssb/lds/core/saga/SagaExecutionCoordinator.java
@@ -90,6 +90,10 @@ public class SagaExecutionCoordinator {
         threadPoolWatchDog = new ThreadPoolWatchDog();
     }
 
+    public SagaRepository getSagaRepository() {
+        return sagaRepository;
+    }
+
     public void startThreadpoolWatchdog() {
         threadPoolWatchDog.start();
     }

--- a/src/main/java/no/ssb/lds/core/saga/SagaRepository.java
+++ b/src/main/java/no/ssb/lds/core/saga/SagaRepository.java
@@ -19,7 +19,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SagaRepository {
 
     public static final String SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE = "Create or update managed resource";
+    public static final String SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE_NO_TX_LOG = "Create or update managed resource without writing to transaction log";
     public static final String SAGA_DELETE_MANAGED_RESOURCE = "Delete managed resource";
+    public static final String SAGA_DELETE_MANAGED_RESOURCE_NO_TX_LOG = "Delete managed resource without writing to transaction log";
 
     final Map<String, Saga> sagaByName = new ConcurrentHashMap<>();
 
@@ -37,7 +39,9 @@ public class SagaRepository {
         }
 
         register(buildCreateOrUpdateSaga(indexer));
+        register(buildCreateOrUpdateSagaWithoutTransactionLog(indexer));
         register(buildDeleteSaga(indexer));
+        register(buildDeleteSagaWithoutTransactionLog(indexer));
     }
 
     private Saga buildCreateOrUpdateSaga(SearchIndex indexer) {
@@ -53,6 +57,20 @@ public class SagaRepository {
         return createSagaBuilder.end();
     }
 
+    private Saga buildCreateOrUpdateSagaWithoutTransactionLog(SearchIndex indexer) {
+        Saga.SagaBuilder createSagaBuilder;
+        if (indexer != null) {
+            createSagaBuilder = Saga.start(SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE_NO_TX_LOG)
+                    .linkTo("persistence", "search-index-update");
+            createSagaBuilder.id("search-index-update").adapter(UpdateIndexSagaAdapter.NAME).linkToEnd();
+        } else {
+            createSagaBuilder = Saga.start(SAGA_CREATE_OR_UPDATE_MANAGED_RESOURCE_NO_TX_LOG)
+                    .linkTo("persistence");
+        }
+        createSagaBuilder.id("persistence").adapter(PersistenceCreateOrOverwriteSagaAdapter.NAME).linkToEnd();
+        return createSagaBuilder.end();
+    }
+
     private Saga buildDeleteSaga(SearchIndex indexer) {
         Saga.SagaBuilder deleteSagaBuilder = Saga.start(SAGA_DELETE_MANAGED_RESOURCE)
                 .linkTo("txlog");
@@ -61,6 +79,20 @@ public class SagaRepository {
             deleteSagaBuilder.id("search-index-delete").adapter(DeleteIndexSagaAdapter.NAME).linkToEnd();
         } else {
             deleteSagaBuilder.id("txlog").adapter(DeleteTxLogAdapter.NAME).linkTo("persistence");
+        }
+        deleteSagaBuilder.id("persistence").adapter(PersistenceDeleteSagaAdapter.NAME).linkToEnd();
+        return deleteSagaBuilder.end();
+    }
+
+    private Saga buildDeleteSagaWithoutTransactionLog(SearchIndex indexer) {
+        Saga.SagaBuilder deleteSagaBuilder;
+        if (indexer != null) {
+            deleteSagaBuilder = Saga.start(SAGA_DELETE_MANAGED_RESOURCE_NO_TX_LOG)
+                    .linkTo("persistence", "search-index-delete");
+            deleteSagaBuilder.id("search-index-delete").adapter(DeleteIndexSagaAdapter.NAME).linkToEnd();
+        } else {
+            deleteSagaBuilder = Saga.start(SAGA_DELETE_MANAGED_RESOURCE_NO_TX_LOG)
+                    .linkTo("persistence");
         }
         deleteSagaBuilder.id("persistence").adapter(PersistenceDeleteSagaAdapter.NAME).linkToEnd();
         return deleteSagaBuilder.end();

--- a/src/test/java/no/ssb/lds/core/restore/RestoreTest.java
+++ b/src/test/java/no/ssb/lds/core/restore/RestoreTest.java
@@ -1,0 +1,153 @@
+package no.ssb.lds.core.restore;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import de.huxhorn.sulky.ulid.ULID;
+import no.ssb.lds.api.persistence.Transaction;
+import no.ssb.lds.api.persistence.json.JsonTools;
+import no.ssb.lds.api.persistence.reactivex.RxJsonPersistence;
+import no.ssb.lds.core.txlog.TxlogRawdataPool;
+import no.ssb.lds.test.ConfigurationOverride;
+import no.ssb.lds.test.client.TestClient;
+import no.ssb.lds.test.server.TestServer;
+import no.ssb.lds.test.server.TestServerListener;
+import no.ssb.rawdata.api.RawdataClient;
+import no.ssb.rawdata.api.RawdataConsumer;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+import java.util.concurrent.TimeUnit;
+
+import static no.ssb.lds.core.utils.FileAndClasspathReaderUtils.readFileOrClasspathResource;
+import static org.testng.Assert.assertEquals;
+
+@Listeners(TestServerListener.class)
+public class RestoreTest {
+
+    @Inject
+    private TestClient client;
+
+    @Inject
+    private TestServer server;
+
+    @Test
+    @ConfigurationOverride({
+            "dummy.with.unique.test.value", "restoreTxLogAndVerify",
+            "txlog.rawdata.provider", "memory",
+            "specification.schema", "spec/demo/contact.json,spec/demo/provisionagreement.json"
+    })
+    public void restoreTxLogAndVerify() throws Exception {
+        produceSevenEntriesAndWipePersistence();
+        JsonNode ctx = initiateRestoreAndWaitForCompletion("default", null);
+
+        // Verify
+        assertEquals(countMessagesInTxLog(), 7);
+        assertEquals(ctx.get("messagesRestored").longValue(), 7);
+        client.get("/data/contact/4b2ef").expect200Ok();
+        client.get("/data/provisionagreement/2a41c").expect200Ok();
+    }
+
+    @Test
+    @ConfigurationOverride({
+            "dummy.with.unique.test.value", "restoreFromThirdElementInclusive",
+            "txlog.rawdata.provider", "memory",
+            "specification.schema", "spec/demo/contact.json,spec/demo/provisionagreement.json"
+    })
+    public void restoreFromThirdElementInclusive() throws Exception {
+        produceSevenEntriesAndWipePersistence();
+        ULID.Value txIdOfThirdElement = getTxIdOfTheNthElement(3);
+        JsonNode ctx = initiateRestoreAndWaitForCompletion("default", "fromInclusive=true&from=" + txIdOfThirdElement.toString());
+
+        // Verify
+        assertEquals(countMessagesInTxLog(), 7);
+        assertEquals(ctx.get("messagesRestored").longValue(), 5);
+        client.get("/data/contact/4b2ef").expect200Ok();
+        client.get("/data/contact/821aa").expect404NotFound();
+        client.get("/data/provisionagreement/2a41c").expect200Ok();
+    }
+
+    @Test
+    @ConfigurationOverride({
+            "dummy.with.unique.test.value", "restoreFromThirdElementExclusive",
+            "txlog.rawdata.provider", "memory",
+            "specification.schema", "spec/demo/contact.json,spec/demo/provisionagreement.json"
+    })
+    public void restoreFromThirdElementExclusive() throws Exception {
+        produceSevenEntriesAndWipePersistence();
+        ULID.Value txIdOfThirdElement = getTxIdOfTheNthElement(3);
+        JsonNode ctx = initiateRestoreAndWaitForCompletion("default", "fromInclusive=false&from=" + txIdOfThirdElement.toString());
+
+        // Verify
+        assertEquals(countMessagesInTxLog(), 7);
+        assertEquals(ctx.get("messagesRestored").longValue(), 4);
+        client.get("/data/contact/4b2ef").expect404NotFound();
+        client.get("/data/contact/821aa").expect404NotFound();
+        client.get("/data/provisionagreement/2a41c").expect200Ok();
+    }
+
+    private ULID.Value getTxIdOfTheNthElement(int n) throws Exception {
+        ULID.Value txIdOfNthElement = null;
+        TxlogRawdataPool txlogRawdataPool = server.getApplication().getTxlogRawdataPool();
+        RawdataClient rawdataClient = txlogRawdataPool.getClient();
+        String txLogTopic = txlogRawdataPool.topicOf(null);
+        try (RawdataConsumer consumer = rawdataClient.consumer(txLogTopic)) {
+            for (int i = 0; i < n; i++) {
+                txIdOfNthElement = consumer.receive(0, TimeUnit.MILLISECONDS).ulid();
+            }
+        }
+        return txIdOfNthElement;
+    }
+
+    private JsonNode initiateRestoreAndWaitForCompletion(String source, String queryString) throws InterruptedException {
+        String uri = "/restore/" + source + (queryString == null ? "" : ("?" + queryString));
+        String snapshotState = client.post(uri).expect200Ok().body();
+        JsonNode ctx = JsonTools.toJsonNode(snapshotState);
+        System.out.printf("%s%n", JsonTools.toPrettyJson(ctx));
+
+        while (!ctx.get("done").booleanValue()) {
+            Thread.sleep(1000);
+            snapshotState = client.get("/restore/" + source).expect200Ok().body();
+            ctx = JsonTools.toJsonNode(snapshotState);
+            System.out.printf("%s%n", JsonTools.toPrettyJson(ctx));
+        }
+        return ctx;
+    }
+
+    private void produceSevenEntriesAndWipePersistence() throws Exception {
+        /*
+         * Produce 7 entries in tx-log through http api
+         */
+        client.put("/data/provisionagreement/2a41c?sync=true&source=test&sourceId=abc123", readFileOrClasspathResource("demo/1-sirius.json")).expect201Created();
+        client.put("/data/provisionagreement/2a41c/address?sync=true", readFileOrClasspathResource("demo/2-sirius-address.json")).expect200Ok();
+        client.put("/data/contact/4b2ef?sync=true", readFileOrClasspathResource("demo/3-skrue.json")).expect201Created();
+        client.put("/data/contact/821aa?sync=true", readFileOrClasspathResource("demo/4-donald.json")).expect201Created();
+        client.put("/data/provisionagreement/2a41c/contacts/contact/4b2ef?sync=true").expect200Ok();
+        client.put("/data/provisionagreement/2a41c/contacts/contact/821aa?sync=true").expect200Ok();
+        client.delete("/data/contact/821aa?sync=true").expect204NoContent();
+
+        assertEquals(countMessagesInTxLog(), 7);
+
+        client.get("/data/contact/4b2ef").expect200Ok();
+        client.get("/data/provisionagreement/2a41c").expect200Ok();
+        RxJsonPersistence persistence = server.getApplication().getPersistence();
+        try (Transaction tx = persistence.createTransaction(false)) {
+            persistence.deleteAllEntities(tx, "data", "provisionagreement", server.getApplication().getSpecification()).blockingAwait();
+            persistence.deleteAllEntities(tx, "data", "contact", server.getApplication().getSpecification()).blockingAwait();
+        }
+        client.get("/data/contact/4b2ef").expect404NotFound();
+        client.get("/data/provisionagreement/2a41c").expect404NotFound();
+    }
+
+    private long countMessagesInTxLog() throws Exception {
+        long count = 0;
+        TxlogRawdataPool txlogRawdataPool = server.getApplication().getTxlogRawdataPool();
+        RawdataClient rawdataClient = txlogRawdataPool.getClient();
+        String txLogTopic = txlogRawdataPool.topicOf(null);
+        try (RawdataConsumer consumer = rawdataClient.consumer(txLogTopic)) {
+            while (consumer.receive(0, TimeUnit.MILLISECONDS) != null) {
+                count++;
+            }
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
This feature will allow LDS administrators to restore data from the transaction-log.

There is also a feature that allows clients to avoid writing entries to the transaction-log when adding data.